### PR TITLE
Offer compound learning pass after feed sweeps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Tend Feed Thread Protocol
+
+- Read `RUNBOOK.md` before operating a feed.
+- Drain pending work with `work:list` and repeated `work:claim` calls for the exact feed and home
+  thread. Complete each claimed item from current state.
+- When a meaningful sweep or refresh reaches the CLI idle handshake, ask the user: `Want me to
+  compound what I learned from this sweep?`
+- `Compound` means: review the sweep's cards, feedback, outcomes, and prior policy; queue
+  `learning:request --feed <id>` after the user agrees; return an editable policy proposal; and
+  never apply it without user approval.
+- If the user asks to compound and search again, compound first. Recollect after the reviewed policy
+  proposal is applied, or after the user explicitly says to continue without applying it.
+- Do not repeat the compound question when a wake begins idle and no meaningful sweep or refresh
+  happened in the current turn.
+- Never perform an external mutation without the app's exact visible approval and a fresh
+  `action:verify`.

--- a/CAPABILITY_MAP.md
+++ b/CAPABILITY_MAP.md
@@ -20,7 +20,7 @@
 | Collect evidence | Render the resulting cards | `source:record-run` or `source:import-json-file` writes immutable snapshots and checkpoints; `sweep:record-batch` records the judged batch separately |
 | Rejudge sweep feedback | Submit dock feedback to `This sweep` | `sweep:rejudge` writes an explicit kept order and removed-card set before recollection is offered |
 | Render a judged item | Review its structured blocks | `card:upsert --feed ... --card ...` |
-| Compound learning | Answer yes when the feed thread offers a learning pass; review and edit the resulting full-screen policy proposal before applying it | `learning:request --feed ...` queues one `compound_learnings` job; Codex reviews durable evidence and uses `revision:propose --source compound`; the browser applies only the user-reviewed Markdown |
+| Compound learning | Answer yes when the feed thread offers its end-of-sweep learning pass; review and edit the resulting full-screen policy proposal before applying it | An idle `work:list` or `work:claim` reminds Codex to offer the pass after meaningful sweep work; `learning:request --feed ...` queues one `compound_learnings` job; Codex reviews durable evidence and uses `revision:propose --source compound`; the browser applies only the user-reviewed Markdown |
 | Revert micro-learning | Review policy history | `policy:revert --feed ... --revision ...` |
 
 The app deliberately exposes atomic primitives. A new feed should usually require new recipe prose,

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ Prompt files describe how to judge, compose cards, execute work, distill small p
 and compound deeper learnings. Feed policy files remain compact and human-readable. Raw snapshots
 stay immutable so the policy can be rebuilt or evaluated later.
 
-At the end of a sweep, the feed thread may ask whether to compound learnings. After the user agrees,
-Codex queues `learning:request`, reviews the durable evidence, and creates a compact feed-policy
-revision with `revision:propose --source compound`. The browser opens a dedicated learning-review
-screen. The user can edit the proposed Markdown and apply or reject it; Codex never applies a
-compounded policy change on its own.
+At the end of a meaningful sweep, the idle CLI handshake tells the feed thread to ask whether to
+compound learnings. After the user agrees, Codex queues `learning:request`, reviews the durable
+evidence, and creates a compact feed-policy revision with `revision:propose --source compound`. The
+browser opens a dedicated learning-review screen. The user can edit the proposed Markdown and apply
+or reject it; Codex never applies a compounded policy change on its own.
 
 The in-app-browser `Prompts & sources` workspace is a full screen rather than a dialog. `This feed`
 edits the active feed policy and source recipes. `Global prompts` edits `global-policy.md` and the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -41,8 +41,27 @@ before acting:
 pnpm cli -- action:verify --feed <feed-id> --work <work-id> --token <capability-token>
 ```
 
-Repeat claim until it returns `null`. An active claimed item is replayed so restart recovery stays
-simple and visible.
+Repeat claim until it returns the idle handshake. An active claimed item is replayed so restart
+recovery stays simple and visible.
+
+## End Of Sweep
+
+After a meaningful sweep or refresh reaches the idle handshake, always ask:
+
+> Want me to compound what I learned from this sweep?
+
+`Compound` means:
+
+1. Review this sweep's cards, feedback, outcomes, and prior policy.
+2. After the user agrees, queue `pnpm cli -- learning:request --feed <feed-id>`.
+3. Drain the resulting `compound_learnings` job and return an editable policy proposal.
+4. Never apply the proposal without user approval.
+
+If the user asks to compound and search again, compound first. Recollect after the reviewed policy
+proposal is applied, or after the user explicitly says to continue without applying it.
+
+Do not repeat the question when a wake begins idle and no meaningful sweep or refresh happened in
+the current turn.
 
 Dock work includes its explicit `target` and `intent`. Interpret the utterance from current state:
 write back cards, source changes, reranked sweeps, or a revision proposal as appropriate. Do not

--- a/cli.ts
+++ b/cli.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { AttentionDomain } from "./server/domain";
+import { formatWorkClaimOutput, formatWorkListOutput } from "./server/operator";
 import { AttentionStore } from "./server/store";
 
 const root = path.dirname(fileURLToPath(import.meta.url));
@@ -186,10 +187,16 @@ switch (command) {
     output = await domain.undoDismiss(required("feed"), required("card"));
     break;
   case "work:list":
-    output = await domain.listPendingWork(required("feed"), required("thread"), flag("cross-feed"));
+    {
+      const feedId = required("feed");
+      output = formatWorkListOutput(feedId, await domain.listPendingWork(feedId, required("thread"), flag("cross-feed")));
+    }
     break;
   case "work:claim":
-    output = await domain.claimWork(required("feed"), required("thread"), flag("cross-feed"));
+    {
+      const feedId = required("feed");
+      output = formatWorkClaimOutput(feedId, await domain.claimWork(feedId, required("thread"), flag("cross-feed")));
+    }
     break;
   case "work:cancel":
     output = await domain.cancelQueuedWork(required("feed"), required("work"), value("reason"));

--- a/server/operator.ts
+++ b/server/operator.ts
@@ -1,0 +1,33 @@
+import type { WorkItem } from "../src/types";
+
+export interface IdleWorkHandshake {
+  status: "idle";
+  next: "offer_compound_if_sweep_finished";
+  message: string;
+  compound: {
+    meaning: string;
+    ifApproved: string;
+    ifApprovedWithSearch: string;
+  };
+}
+
+export function idleWorkHandshake(feedId: string): IdleWorkHandshake {
+  return {
+    status: "idle",
+    next: "offer_compound_if_sweep_finished",
+    message: 'If you completed or refreshed this feed during this turn, ask the user: "Want me to compound what I learned from this sweep?" If this wake began idle, stop quietly rather than repeating the question.',
+    compound: {
+      meaning: "Review this sweep's cards, feedback, outcomes, and prior policy. Distill an editable feed-policy proposal. Never apply it without user approval.",
+      ifApproved: `Run \`pnpm cli -- learning:request --feed ${feedId}\`, drain the resulting compound_learnings job, and return the editable proposal for review.`,
+      ifApprovedWithSearch: "Compound first. Recollect only after the reviewed policy proposal is applied, or after the user explicitly says to continue without applying it.",
+    },
+  };
+}
+
+export function formatWorkListOutput(feedId: string, work: WorkItem[]): WorkItem[] | IdleWorkHandshake {
+  return work.length > 0 ? work : idleWorkHandshake(feedId);
+}
+
+export function formatWorkClaimOutput(feedId: string, work: WorkItem | null): WorkItem | IdleWorkHandshake {
+  return work ?? idleWorkHandshake(feedId);
+}

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -3,7 +3,9 @@ import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promis
 import os from "node:os";
 import path from "node:path";
 import { AttentionDomain } from "../server/domain";
+import { formatWorkClaimOutput, formatWorkListOutput } from "../server/operator";
 import { AttentionStore } from "../server/store";
+import type { WorkItem } from "../src/types";
 import { closestTarget, preferredTarget } from "../src/state/voiceTarget";
 
 const roots: string[] = [];
@@ -18,6 +20,27 @@ async function setup() {
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("feed thread operator handshake", () => {
+  test("offers a compound pass when a work list or claim reaches idle", () => {
+    const idleList = formatWorkListOutput("hiring", []);
+    const idleClaim = formatWorkClaimOutput("hiring", null);
+
+    expect(idleList).toMatchObject({
+      status: "idle",
+      next: "offer_compound_if_sweep_finished",
+    });
+    expect(idleClaim).toEqual(idleList);
+    expect(idleClaim.compound.ifApproved).toContain("learning:request --feed hiring");
+    expect(idleClaim.message).toContain("Want me to compound what I learned from this sweep?");
+  });
+
+  test("keeps pending work output unchanged", () => {
+    const work = { id: "work-1" } as WorkItem;
+    expect(formatWorkListOutput("inbox", [work])).toEqual([work]);
+    expect(formatWorkClaimOutput("inbox", work)).toBe(work);
+  });
 });
 
 describe("filesystem workspace", () => {


### PR DESCRIPTION
## Problem

Feed-owned Codex threads could drain a meaningful sweep to idle without knowing they should ask whether to compound learnings. The meaning of `compound` was present in the product, but too implicit for a fresh feed thread to execute reliably.

## Fix

- Return an explicit idle handshake from `work:list` and `work:claim` after the queue drains. It includes the user-facing question, the exact `learning:request` command, the approval boundary, and the compound-before-recollect rule.
- Add a repo-level `AGENTS.md` protocol so Codex threads inherit the same behavior when operating Tend.
- Update the runbook, README, and capability map to make the end-of-sweep handshake part of the normal worker loop.
- Preserve the existing JSON shape whenever actual pending work exists.

## Verification

- `pnpm test` (`52` passing)
- `pnpm build`
- Temporary-workspace CLI walkthrough confirming both idle `work:list` and idle `work:claim` return `offer_compound_if_sweep_finished` with the exact follow-up instructions.