### PR TITLE
feat: surface pending learning proposals in feed tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,14 @@ export function parkedClaudeWorkItems(feed: FeedView, claudeLiveness: string): P
     }));
 }
 
+export function pendingCompoundProposalsForFeed(proposals: RevisionProposal[], feedId: string): RevisionProposal[] {
+  return proposals.filter((proposal) =>
+    proposal.anchorFeedId === feedId
+    && proposal.source === "compound"
+    && proposal.status === "proposed"
+  );
+}
+
 export function ParkedClaudeWorkNotice({ items, onReassign }: { items: ParkedClaudeWork[]; onReassign: (work: WorkItemView) => void }) {
   if (!items.length) return null;
   return (
@@ -406,7 +414,7 @@ export default function App({ feedId, screen, workspaceTab }: { feedId: string; 
 
   if (!state || !feed) return withRealtime(<main className="loading">Loading attention…</main>);
   const resolvedDockTarget = dockTarget ?? ladder[0];
-  const compoundProposals = state.proposals.filter((proposal) => proposal.anchorFeedId === feed.config.id && proposal.source === "compound" && proposal.status === "proposed");
+  const compoundProposals = pendingCompoundProposalsForFeed(state.proposals, feed.config.id);
   const workAgent = (work: WorkItemView) => effectiveWorkLane(work, feed.thread);
   const workAgentLabel = (work: WorkItemView) => agentLabel(workAgent(work));
   const cardQueuedFor = (cardId: string) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,25 @@ export function ParkedClaudeWorkNotice({ items, onReassign }: { items: ParkedCla
   );
 }
 
+export function FeedTabs({ feed, tab, queuedTabLabel, compoundProposalCount, onTab, onLearningProposals, onWorkspace }: { feed: FeedView; tab: Tab; queuedTabLabel: string; compoundProposalCount: number; onTab: (tab: Tab) => void; onLearningProposals: () => void; onWorkspace: () => void }) {
+  return (
+    <nav className="tabs">
+      {(["review", "queued", "working", "done"] as Tab[]).map((item) => (
+        <button key={item} className={tab === item ? "active" : ""} onClick={() => onTab(item)}>
+          {item === "review" ? "To review" : item === "queued" ? queuedTabLabel : item === "working" ? "Working" : "Done"}
+          <span>{countFor(feed, item)}</span>
+        </button>
+      ))}
+      {compoundProposalCount > 0 && (
+        <button className="tab-learning" onClick={onLearningProposals}>
+          Learning proposals <span>{compoundProposalCount}</span>
+        </button>
+      )}
+      <button className="tab-quiet" onClick={onWorkspace}>Prompts & sources</button>
+    </nav>
+  );
+}
+
 export default function App({ feedId, screen, workspaceTab }: { feedId: string; screen: AttentionScreen; workspaceTab: WorkspaceTab }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -387,7 +406,7 @@ export default function App({ feedId, screen, workspaceTab }: { feedId: string; 
 
   if (!state || !feed) return withRealtime(<main className="loading">Loading attention…</main>);
   const resolvedDockTarget = dockTarget ?? ladder[0];
-  const compoundProposals = state.proposals.filter((proposal) => proposal.anchorFeedId === feed.config.id && proposal.source === "compound");
+  const compoundProposals = state.proposals.filter((proposal) => proposal.anchorFeedId === feed.config.id && proposal.source === "compound" && proposal.status === "proposed");
   const workAgent = (work: WorkItemView) => effectiveWorkLane(work, feed.thread);
   const workAgentLabel = (work: WorkItemView) => agentLabel(workAgent(work));
   const cardQueuedFor = (cardId: string) => {
@@ -425,15 +444,15 @@ export default function App({ feedId, screen, workspaceTab }: { feedId: string; 
   return withRealtime(
     <>
       <TopBar state={state} onMind={openMind} onFeed={changeFeed} onInspector={setInspector} onWorkspace={openWorkspace} />
-      <nav className="tabs">
-        {(["review", "queued", "working", "done"] as Tab[]).map((item) => (
-          <button key={item} className={tab === item ? "active" : ""} onClick={() => setTab(item)}>
-            {item === "review" ? "To review" : item === "queued" ? queuedTabLabel : item === "working" ? "Working" : "Done"}
-            <span>{countFor(feed, item)}</span>
-          </button>
-        ))}
-        <button className="tab-quiet" onClick={() => openWorkspace("feed")}>Prompts & sources</button>
-      </nav>
+      <FeedTabs
+        feed={feed}
+        tab={tab}
+        queuedTabLabel={queuedTabLabel}
+        compoundProposalCount={compoundProposals.length}
+        onTab={setTab}
+        onLearningProposals={openLearningReview}
+        onWorkspace={() => openWorkspace("feed")}
+      />
       <main className="page" ref={pageRef}>
         <RevisionProposals proposals={state.proposals} onApply={applyProposal} onReject={rejectProposal} onReviewLearning={openLearningReview} />
         {routineActions.map((group) => <RoutineActionGroupView key={group.id} group={group} onApprove={() => approveRoutineAction(group)} />)}

--- a/src/styles.css
+++ b/src/styles.css
@@ -44,6 +44,9 @@ kbd { font: 11px/1 var(--mono); color: var(--ink-3); }
 .tabs button.active { color: var(--ink); border-color: var(--ink); }
 .tabs span { color: var(--ink-4); font-size: 12px; }
 .tabs .tab-quiet { margin-left: auto; color: var(--ink-3); }
+.tabs .tab-learning { margin-left: auto; color: #8a693f; font-weight: 700; }
+.tabs .tab-learning + .tab-quiet { margin-left: 0; }
+.tabs .tab-learning span { display: grid; place-items: center; min-width: 19px; height: 19px; padding: 0 5px; border-radius: 99px; background: #f3ede2; color: #8a693f; }
 
 .page { max-width: 980px; margin: 0 auto; padding: 22px 34px 190px; }
 .panel-kicker, .section-label, .action-label { color: var(--ink-3); font-size: 11px; font-weight: 700; letter-spacing: .13em; text-transform: uppercase; }

--- a/test/app-card-disposition.test.tsx
+++ b/test/app-card-disposition.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createMemoryHistory, createRootRoute, createRoute, createRouter, RouterProvider } from "@tanstack/react-router";
@@ -6,7 +6,11 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import App from "../src/App";
 import type { Card, FeedView, WorkspaceView } from "../shared/types";
 
-GlobalRegistrator.register();
+beforeAll(() => GlobalRegistrator.register());
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister();
+});
 
 class StubEventSource {
   onerror: ((event: Event) => void) | null = null;

--- a/test/routing-ui-render.test.tsx
+++ b/test/routing-ui-render.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { Children, isValidElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { FeedTabs, ParkedClaudeWorkNotice, parkedClaudeWorkItems } from "../src/App";
+import { FeedTabs, ParkedClaudeWorkNotice, parkedClaudeWorkItems, pendingCompoundProposalsForFeed } from "../src/App";
 import { Dock } from "../src/shell/Dock";
 import { TopBar } from "../src/shell/TopBar";
 import { LearningReview, RevisionProposals } from "../src/workspace/LearningReview";
@@ -72,6 +72,32 @@ test("TopBar renders Claude presence liveness and label", () => {
   expect(html).toContain("tend-agent-live");
 });
 
+test("pending compound proposals are scoped to the active feed and unresolved status", () => {
+  const proposal = (id: string, overrides: Partial<RevisionProposal> = {}): RevisionProposal => ({
+    id,
+    anchorFeedId: "inbox",
+    target: { kind: "feed", feedId: "inbox" },
+    label: "Inbox feed policy",
+    instruction: "Preserve a useful learning.",
+    previous: "Current policy text.",
+    next: "Proposed policy text.",
+    source: "compound",
+    status: "proposed",
+    createdAt: "2026-07-15T12:00:00.000Z",
+    ...overrides,
+  });
+
+  const pending = pendingCompoundProposalsForFeed([
+    proposal("pending"),
+    proposal("applied", { status: "applied" }),
+    proposal("rejected", { status: "rejected" }),
+    proposal("other-feed", { anchorFeedId: "company-attention" }),
+    proposal("voice", { source: "voice" }),
+  ], "inbox");
+
+  expect(pending.map((item) => item.id)).toEqual(["pending"]);
+});
+
 test("feed tabs keep a count-aware learning proposals control visible while proposals are pending", () => {
   const active = feed();
   let openedLearningReview = false;
@@ -87,7 +113,7 @@ test("feed tabs keep a count-aware learning proposals control visible while prop
   const withProposals = renderToStaticMarkup(
     <FeedTabs
       feed={active}
-      tab="review"
+      tab="done"
       queuedTabLabel="Queued for Codex"
       compoundProposalCount={2}
       onTab={() => {}}

--- a/test/routing-ui-render.test.tsx
+++ b/test/routing-ui-render.test.tsx
@@ -1,9 +1,11 @@
 import { expect, test } from "bun:test";
+import { Children, isValidElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { ParkedClaudeWorkNotice, parkedClaudeWorkItems } from "../src/App";
+import { FeedTabs, ParkedClaudeWorkNotice, parkedClaudeWorkItems } from "../src/App";
 import { Dock } from "../src/shell/Dock";
 import { TopBar } from "../src/shell/TopBar";
-import type { Card, FeedView, WorkItemView, WorkspaceView } from "../shared/types";
+import { LearningReview, RevisionProposals } from "../src/workspace/LearningReview";
+import type { Card, FeedView, RevisionProposal, WorkItemView, WorkspaceView } from "../shared/types";
 
 function feed(overrides: Partial<FeedView> = {}): FeedView {
   return {
@@ -68,6 +70,84 @@ test("TopBar renders Claude presence liveness and label", () => {
 
   expect(html).toContain("Claude live · Preview");
   expect(html).toContain("tend-agent-live");
+});
+
+test("feed tabs keep a count-aware learning proposals control visible while proposals are pending", () => {
+  const active = feed();
+  let openedLearningReview = false;
+  const tabs = FeedTabs({
+    feed: active,
+    tab: "review",
+    queuedTabLabel: "Queued for Codex",
+    compoundProposalCount: 2,
+    onTab: () => {},
+    onLearningProposals: () => { openedLearningReview = true; },
+    onWorkspace: () => {},
+  });
+  const withProposals = renderToStaticMarkup(
+    <FeedTabs
+      feed={active}
+      tab="review"
+      queuedTabLabel="Queued for Codex"
+      compoundProposalCount={2}
+      onTab={() => {}}
+      onLearningProposals={() => {}}
+      onWorkspace={() => {}}
+    />,
+  );
+  const withoutProposals = renderToStaticMarkup(
+    <FeedTabs
+      feed={active}
+      tab="review"
+      queuedTabLabel="Queued for Codex"
+      compoundProposalCount={0}
+      onTab={() => {}}
+      onLearningProposals={() => {}}
+      onWorkspace={() => {}}
+    />,
+  );
+
+  expect(withProposals).toContain("tab-learning");
+  expect(withProposals).toContain("Learning proposals");
+  expect(withProposals).toContain("<span>2</span>");
+  expect(withoutProposals).not.toContain("Learning proposals");
+
+  const learningButton = Children.toArray(tabs.props.children).find((child) =>
+    isValidElement<{ className?: string }>(child) && child.props.className === "tab-learning"
+  );
+  if (!isValidElement<{ onClick: () => void }>(learningButton)) throw new Error("Learning proposals control was not rendered.");
+  learningButton.props.onClick();
+  expect(openedLearningReview).toBe(true);
+});
+
+test("compound proposals stay in the proposal stack and apply only from the full learning review", () => {
+  const proposal: RevisionProposal = {
+    id: "proposal-compound",
+    anchorFeedId: "inbox",
+    target: { kind: "feed", feedId: "inbox" },
+    label: "Inbox feed policy",
+    instruction: "Preserve a useful learning.",
+    previous: "Current policy text.",
+    next: "Proposed editable policy text.",
+    source: "compound",
+    status: "proposed",
+    createdAt: "2026-07-15T12:00:00.000Z",
+  };
+  const stack = renderToStaticMarkup(
+    <RevisionProposals proposals={[proposal]} onApply={() => {}} onReject={() => {}} onReviewLearning={() => {}} />,
+  );
+  const review = renderToStaticMarkup(
+    <LearningReview feed={feed()} proposals={[proposal]} onBack={() => {}} onApply={() => {}} onReject={() => {}} />,
+  );
+
+  expect(stack).toContain("Current policy text.");
+  expect(stack).toContain("Proposed editable policy text.");
+  expect(stack).toContain("Review compounded learnings");
+  expect(stack).not.toContain("Apply revision");
+  expect(review).toContain("Current feed policy");
+  expect(review).toContain("Current policy text.");
+  expect(review).toContain("Proposed editable policy text.");
+  expect(review).toContain("Apply learning");
 });
 
 test("Dock renders Claude routing toggle and agent-aware placeholder", () => {


### PR DESCRIPTION
## Summary

Keep pending compound learnings discoverable from anywhere in a feed review.

- add a persistent, count-aware **Learning proposals** control to the feed tab strip
- show it only while the active feed has unresolved compound proposals
- route directly to the existing full learning-review screen
- remove applied or rejected proposals from the pending count

## Impact

This is a presentation-layer change. It does not change the learning workflow, API, domain, schema, or approval boundary. Compound proposals remain editable and can be applied only from the dedicated learning review.

## Validation

- `pnpm check`: 218 passed, 1 environment-gated Supabase test skipped, 0 failed
- Bun 1.3.11 randomized-order regression run, including DOM tests before API Origin checks
- pending-proposal coverage spans active feed, status, source, count, cross-tab visibility, and navigation callback
- `pnpm build`
- `pnpm tend:build`
- `pnpm tend:smoke`
- `pnpm tend:package`
- `git diff --check`
