### PR TITLE
fix(backup): preserve original data when import fails

### DIFF
--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -63,7 +63,9 @@ tend-backup/
 file mirrors and immutable raw evidence snapshots. Export writes through a temporary staging
 directory and refuses to overwrite or delete an existing destination.
 
-Import first copies the backup into a temporary staging directory. Tend refuses to import while
-the same runtime home is active, then swaps the staged database and data into place with rollback if
-the swap fails. Older data-directory-only backups are still accepted; the next local runtime start
-rehydrates `attention.db` from those imported file mirrors.
+Import requires an explicit source containing a Tend database or `workspace.json`.
+It stages and opens the replacement under the runtime home before moving any current data.
+Older data-directory-only backups are rehydrated in staging.
+Tend refuses to import while its configured API reports the same home active.
+If replacement fails, rollback restores only files that were moved.
+If rollback fails, the error identifies the preserved recovery directory instead of deleting it.

--- a/server/cli/backup.ts
+++ b/server/cli/backup.ts
@@ -1,9 +1,9 @@
 import { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
-import { cp, mkdir, mkdtemp, rename, rm, stat, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { cp, mkdir, mkdtemp, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { attentionDataDir, attentionDbPath, attentionHome } from "../paths";
+import { createLocalRuntime } from "../runtime";
 import { SQLITE_SCHEMA_VERSION } from "../sqlite";
 import { withMutationLock } from "../util";
 import { apiUrl, initRuntime, print } from "./shared";
@@ -46,29 +46,44 @@ export async function backupExportCommand(targetPath: string): Promise<void> {
 }
 
 export async function backupImportCommand(sourcePath: string): Promise<void> {
-  const source = path.resolve(sourcePath);
+  if (!sourcePath.trim()) throw new Error("Backup import requires a source path.");
+  let source = path.resolve(sourcePath);
   if (!existsSync(source)) throw new Error(`Backup path does not exist: ${source}`);
+  source = await realpath(source);
   await assertRuntimeStopped();
 
   const bundledData = path.join(source, "data");
   const bundledDb = path.join(source, "attention.db");
-  const sourceData = existsSync(bundledData) ? bundledData : source;
+  const sourceData = await realpath(existsSync(bundledData) ? bundledData : source);
   if (!(await stat(sourceData)).isDirectory()) throw new Error(`Backup data is not a directory: ${sourceData}`);
+  if (!existsSync(bundledDb) && !existsSync(path.join(sourceData, "workspace.json"))) {
+    throw new Error("Backup is missing a Tend database or workspace.json.");
+  }
 
-  const home = path.resolve(attentionHome());
-  await mkdir(path.dirname(home), { recursive: true });
-  const stage = await mkdtemp(path.join(os.tmpdir(), "attention-import-"));
+  await mkdir(attentionHome(), { recursive: true });
+  const home = await realpath(attentionHome());
+  const dataDir = existsSync(attentionDataDir()) ? await realpath(attentionDataDir()) : path.join(home, "data");
+  if (isWithin(sourceData, home) || isWithin(dataDir, source) || isWithin(dataDir, sourceData)) throw new Error("Backup source must be outside the data being replaced and cannot contain the runtime home.");
+  const stage = await mkdtemp(path.join(home, ".attention-import-"));
   const rollback = path.join(stage, "rollback");
   const stagedData = path.join(stage, "data");
   const stagedDb = path.join(stage, "attention.db");
+  let preserveRollback = false;
   try {
-    await cp(sourceData, stagedData, { recursive: true });
+    await cp(sourceData, stagedData, { recursive: true, dereference: true });
     await rm(path.join(stagedData, ".mutation-lock"), { recursive: true, force: true });
     if (existsSync(bundledDb)) {
       await cp(bundledDb, stagedDb);
       validateSqliteBackup(stagedDb);
     }
-    await mkdir(home, { recursive: true });
+    const stagedRuntime = await createLocalRuntime(stagedData, stagedDb);
+    try {
+      for (const feedId of await stagedRuntime.store.listFeedIds()) {
+        await stagedRuntime.store.readFeed(feedId);
+      }
+    } finally {
+      stagedRuntime.sqlite.close();
+    }
     await mkdir(rollback, { recursive: true });
 
     const currentFiles = [
@@ -78,6 +93,7 @@ export async function backupImportCommand(sourcePath: string): Promise<void> {
       `${attentionDbPath()}-wal`,
     ];
     const moved: Array<{ from: string; to: string }> = [];
+    const installed: string[] = [];
     try {
       for (const current of currentFiles) {
         if (!existsSync(current)) continue;
@@ -86,17 +102,21 @@ export async function backupImportCommand(sourcePath: string): Promise<void> {
         moved.push({ from: backup, to: current });
       }
       await rename(stagedData, attentionDataDir());
-      if (existsSync(stagedDb)) await rename(stagedDb, attentionDbPath());
+      installed.push(attentionDataDir());
+      await rename(stagedDb, attentionDbPath());
+      installed.push(attentionDbPath());
     } catch (error) {
-      await rm(attentionDataDir(), { recursive: true, force: true });
-      await removeSqliteFiles();
-      for (const item of moved.reverse()) {
-        if (existsSync(item.from)) await rename(item.from, item.to);
+      try {
+        for (const file of installed.reverse()) await rm(file, { recursive: true, force: true });
+        for (const item of moved.reverse()) await rename(item.from, item.to);
+      } catch (rollbackError) {
+        preserveRollback = true;
+        throw new AggregateError([error, rollbackError], `Import and rollback failed. Preserved recovery files at ${rollback}.`);
       }
       throw error;
     }
   } finally {
-    await rm(stage, { recursive: true, force: true });
+    if (!preserveRollback) await rm(stage, { recursive: true, force: true });
   }
 
   print({
@@ -105,7 +125,7 @@ export async function backupImportCommand(sourcePath: string): Promise<void> {
     to: {
       dataDir: attentionDataDir(),
       dbPath: attentionDbPath(),
-      sqlite: existsSync(bundledDb) ? "restored" : "will_rehydrate_from_file_mirrors",
+      sqlite: existsSync(bundledDb) ? "restored" : "rehydrated_from_file_mirrors",
     },
   });
 }
@@ -148,15 +168,7 @@ async function assertRuntimeStopped(): Promise<void> {
   }
 }
 
-async function removeSqliteFiles(): Promise<void> {
-  await Promise.all([
-    rm(attentionDbPath(), { force: true }),
-    rm(`${attentionDbPath()}-shm`, { force: true }),
-    rm(`${attentionDbPath()}-wal`, { force: true }),
-  ]);
-}
-
 function isWithin(parent: string, candidate: string): boolean {
   const relative = path.relative(path.resolve(parent), path.resolve(candidate));
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
 }

--- a/test/backup-import.test.ts
+++ b/test/backup-import.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createLocalRuntime } from "../server/runtime";
+
+for (const failure of ["empty", "invalid", "first", "install", "database", "rollback", "nested", "nested-link", "success"]) {
+  test(`backup import preserves recoverability on ${failure}`, async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "tend-backup-test-"));
+    try {
+      const home = path.join(root, "home");
+      const source = failure.startsWith("nested") ? path.join(home, "data", "saved-backup") : path.join(root, "source");
+      await mkdir(path.join(home, "data"), { recursive: true });
+      const original = await createLocalRuntime(path.join(home, "data"), path.join(home, "attention.db"));
+      original.sqlite.close();
+      const originalDb = await readFile(path.join(home, "attention.db"));
+      await writeFile(path.join(home, "data", "original.txt"), "original");
+      const staged = await createLocalRuntime(path.join(source, "data"), path.join(root, "source.db"));
+      await staged.sqlite.backupTo(path.join(source, "attention.db"));
+      staged.sqlite.close();
+      if (failure === "invalid") await writeFile(path.join(source, "attention.db"), "invalid sqlite");
+      const input = failure === "nested-link" ? path.join(root, "backup-link") : source;
+      if (failure === "nested-link") await symlink(source, input);
+      const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "fixtures", "backup-import.ts"), failure === "empty" ? "" : input, failure], {
+        env: { ...process.env, ATTENTION_HOME: home }, stdout: "pipe", stderr: "pipe",
+      });
+      const [code, stdout, stderr] = await Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]);
+      expect(code === 0).toBe(failure === "success");
+      if (failure === "success") {
+        expect(stdout).toContain('"ok": true');
+        const restored = await createLocalRuntime(path.join(home, "data"), path.join(home, "attention.db"));
+        expect(await restored.store.listFeedIds()).toContain("inbox");
+        restored.sqlite.close();
+      } else if (failure === "rollback") {
+        expect(stderr).toContain("Preserved recovery files");
+        const stage = (await readdir(home)).find((entry) => entry.startsWith(".attention-import-"));
+        expect(stage).toBeDefined();
+        expect(await readFile(path.join(home, stage!, "rollback", "data", "original.txt"), "utf8")).toBe("original");
+      } else {
+        expect(existsSync(path.join(home, "data", "original.txt"))).toBe(true);
+        expect(await readFile(path.join(home, "attention.db"))).toEqual(originalDb);
+        if (failure.startsWith("nested")) expect(existsSync(source)).toBe(true);
+        if (failure === "database") expect(stderr).toContain("Injected database install failure");
+        if (failure === "first") expect(stderr).toContain("Injected first rename failure");
+        if (failure === "install") expect(stderr).toContain("Injected install failure");
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/test/fixtures/backup-import.ts
+++ b/test/fixtures/backup-import.ts
@@ -1,0 +1,25 @@
+import { mock } from "bun:test";
+import * as fs from "node:fs/promises";
+import path from "node:path";
+
+const rename = fs.rename;
+const [source, failure] = process.argv.slice(2);
+const home = process.env.ATTENTION_HOME!;
+mock.module("node:fs/promises", () => ({
+  ...fs,
+  async rename(from: string, to: string) {
+    if (failure === "first" && from === path.join(home, "data")) throw new Error("Injected first rename failure");
+    if ((failure === "install" || failure === "rollback") && from.includes(".attention-import-") && !from.includes("rollback") && to === path.join(home, "data")) throw new Error("Injected install failure");
+    if (failure === "database" && from.includes(".attention-import-") && !from.includes("rollback") && to === path.join(home, "attention.db")) throw new Error("Injected database install failure");
+    if (failure === "rollback" && from.includes("rollback")) throw new Error("Injected rollback failure");
+    return rename(from, to);
+  },
+}));
+globalThis.fetch = async () => new Response(null, { status: 503 });
+const { backupImportCommand } = await import("../../server/cli/backup");
+try {
+  await backupImportCommand(source ?? "");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}


### PR DESCRIPTION
A failed import can delete the current data before any replacement is installed, and a failed rollback can delete its own recovery copy. I validate the replacement in staging and track which paths actually moved so rollback preserves the original files. The regression checks cover invalid input, rename failures, preserved recovery files, and a backup nested inside the data being replaced.
