### PR TITLE
fix(queue): commit queued work before notifying agents

### DIFF
--- a/server/domain.ts
+++ b/server/domain.ts
@@ -701,7 +701,7 @@ export class AttentionDomain {
     if (work.status !== "queued") throw new Error(`Cannot persist non-queued work through queued wake helper: ${work.status}`);
     await this.store.writeWork(work);
     await options.afterWrite?.();
-    await this.maybeEmitClaudeWake(feedId, work, options.thread, options.wake);
+    await this.store.afterCommit(() => this.maybeEmitClaudeWake(feedId, work, options.thread, options.wake));
   }
 
   private requeueWorkItem(work: WorkItem): void {
@@ -1186,7 +1186,7 @@ export class AttentionDomain {
   }
 
   async requestSweepRecollection(feedId: string): Promise<WorkItem> {
-    return this.store.serialize(async () => {
+    return this.store.serializeAtomic(async () => {
       const feed = await this.store.readFeed(feedId);
       const existing = (await this.store.readWorkItems(feedId)).find((work) => work.intent === "recollect_sources" && (work.status === "queued" || work.status === "working"));
       if (existing) return existing;
@@ -1514,13 +1514,13 @@ export class AttentionDomain {
   async queueInstruction(feedId: string, cardId: string, instruction: string, options: { assignee?: WorkAgent } = {}): Promise<WorkItem> {
     if (!instruction.trim()) throw new Error("Instruction is required.");
     await this.assertClaudeRoutingAllowed(feedId, options.assignee);
-    return this.store.serialize(() => this.queueInstructionLocked(feedId, cardId, instruction, undefined, options));
+    return this.store.serializeAtomic(() => this.queueInstructionLocked(feedId, cardId, instruction, undefined, options));
   }
 
   async queueFeedInstruction(feedId: string, instruction: string, options: { assignee?: WorkAgent } = {}): Promise<WorkItem> {
     if (!instruction.trim()) throw new Error("Instruction is required.");
     await this.assertClaudeRoutingAllowed(feedId, options.assignee);
-    return this.store.serialize(async () => {
+    return this.store.serializeAtomic(async () => {
       const work = queuedWork(feedId, "__feed__", instruction, { kind: "instruction", ...(options.assignee ? { assignee: options.assignee } : {}) });
       await this.persistQueuedWork(feedId, work, {
         afterWrite: () => this.store.appendEvent({ feedId, workId: work.id, type: "feed.instruction_queued", detail: { instruction: work.instruction } }),
@@ -1530,7 +1530,7 @@ export class AttentionDomain {
   }
 
   async approveAction(feedId: string, cardId: string, cardActionId?: string): Promise<WorkItem> {
-    return this.store.serialize(() => this.approveActionLocked(feedId, cardId, cardActionId));
+    return this.store.serializeAtomic(() => this.approveActionLocked(feedId, cardId, cardActionId));
   }
 
   async runCardAction(feedId: string, cardId: string, cardActionId: string): Promise<WorkItem | Card> {
@@ -1554,7 +1554,7 @@ export class AttentionDomain {
   // Queue the feed's configured source cleanup as verified work. This can mutate the source
   // connector (for example, archiving an email) and is intentionally separate from local dismissal.
   async queueSourceCleanup(feedId: string, cardId: string): Promise<WorkItem> {
-    return this.store.serialize(() => this.queueSourceCleanupLocked(feedId, cardId));
+    return this.store.serializeAtomic(() => this.queueSourceCleanupLocked(feedId, cardId));
   }
 
   // Local, connector-free dismissal: removes a card from review without creating any WorkItem,
@@ -1643,7 +1643,7 @@ export class AttentionDomain {
   }
 
   async approveRoutineActionGroup(feedId: string, groupId: string): Promise<WorkItem> {
-    return this.store.serialize(() => this.approveRoutineActionGroupLocked(feedId, groupId));
+    return this.store.serializeAtomic(() => this.approveRoutineActionGroupLocked(feedId, groupId));
   }
 
   private async approveRoutineActionGroupLocked(
@@ -1784,7 +1784,7 @@ export class AttentionDomain {
 
   async reassignQueuedWork(feedId: string, workId: string, agent: WorkAgent): Promise<WorkItemView & { warning?: string }> {
     await this.assertClaudeRoutingAllowed(feedId, agent);
-    return this.store.serialize(async () => {
+    return this.store.serializeAtomic(async () => {
       const work = await this.store.readWork(feedId, workId);
       if (work.status !== "queued") throw new Error("Only queued work can be reassigned.");
       if (agent === "codex") {
@@ -1999,7 +1999,7 @@ export class AttentionDomain {
   }
 
   async queueCompound(feedId: string): Promise<WorkItem> {
-    return this.store.serialize(async () => {
+    return this.store.serializeAtomic(async () => {
       const existing = (await this.store.readWorkItems(feedId)).find((work) => work.kind === "compound_learnings" && (work.status === "queued" || work.status === "working"));
       if (existing) return existing;
       const work = queuedWork(feedId, "__feed__", "The user approved a learning pass. Review raw snapshots, runs, events, outcomes, and policy history. Distill a compact feed-policy improvement, then create an editable revision proposal with revision:propose --source compound. Do not apply it. The browser will bring the proposal back to the user for review.", {
@@ -2079,7 +2079,7 @@ export class AttentionDomain {
   }
 
   async releaseWork(feedId: string, workId: string, token: string, sessionId?: string): Promise<WorkItemView> {
-    return this.store.serialize(async () => {
+    return this.store.serializeAtomic(async () => {
       const work = await this.store.readWork(feedId, workId);
       if (work.status !== "working") throw new Error("Only working work can be released.");
       if (work.capabilityToken !== token) throw new Error("Invalid scoped work capability token.");
@@ -2448,7 +2448,8 @@ export class AttentionDomain {
   }
 
   async retryApprovedWork(feedId: string, workId: string): Promise<WorkItemView> {
-    return this.store.serialize(async () => {
+    let staleError: Error | undefined;
+    const retried = await this.store.serializeAtomic(async () => {
       const work = await this.store.readWork(feedId, workId);
       if ((work.status !== "approved_blocked" && work.status !== "failed") || work.kind !== "execute_approved_action" || !work.approvalDigest) {
         throw new Error("Only an approved blocked action can be retried.");
@@ -2467,7 +2468,8 @@ export class AttentionDomain {
         await this.store.writeWork(work);
         await this.store.writeCard(card);
         await this.store.appendEvent({ feedId, cardId: card.id, workId, type: "action.stale" });
-        throw new Error(work.error);
+        staleError = new Error(work.error);
+        return workItemView(work);
       }
       this.requeueWorkItem(work);
       card.status = "queued";
@@ -2480,6 +2482,8 @@ export class AttentionDomain {
       });
       return workItemView(work);
     });
+    if (staleError) throw staleError;
+    return retried;
   }
 
   async createFeedFromBrief(brief: string, currentThreadId: string | null): Promise<FeedConfig> {

--- a/server/store.ts
+++ b/server/store.ts
@@ -89,6 +89,7 @@ export function agentPresenceLiveness(presence: AgentPresence | null, now = Date
 export class AttentionStore {
   readonly dataDir: string;
   private tail = Promise.resolve();
+  private committedCallbacks: Array<() => Promise<unknown>> | null = null;
   private readonly cards: CardRepository;
   private readonly events: FeedEventRepository;
   private readonly mindContext: MindContextRepository;
@@ -629,7 +630,26 @@ export class AttentionStore {
   }
 
   async serializeAtomic<T>(callback: () => Promise<T>): Promise<T> {
-    return this.serialize(() => this.runAtomic ? this.runAtomic(callback) : callback());
+    return this.serialize(async () => {
+      const callbacks: Array<() => Promise<unknown>> = [];
+      this.committedCallbacks = callbacks;
+      let result: T;
+      try {
+        result = await (this.runAtomic ? this.runAtomic(callback) : callback());
+      } finally {
+        this.committedCallbacks = null;
+      }
+      for (const notify of callbacks) {
+        try { await notify(); }
+        catch (error) { console.error("Notification failed after transaction committed:", error); }
+      }
+      return result;
+    });
+  }
+
+  async afterCommit(callback: () => Promise<unknown>): Promise<void> {
+    if (this.committedCallbacks) this.committedCallbacks.push(callback);
+    else await callback();
   }
 
   private async withAgentWakeLock<T>(callback: () => Promise<T>): Promise<T> {

--- a/test/queue-atomicity.test.ts
+++ b/test/queue-atomicity.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { AttentionDomain } from "../server/domain";
+import { createLocalRuntime } from "../server/runtime";
+
+for (const entry of ["card", "feed", "compound", "recollection"] as const) {
+  test(`${entry} queue rolls back when its event cannot be persisted`, async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "tend-atomic-queue-"));
+    const runtime = await createLocalRuntime(path.join(root, "data"), path.join(root, "attention.db"));
+    try {
+      const domain = new AttentionDomain(runtime.store);
+      const before = await runtime.store.readCard("inbox", "inbox-ready-to-collect");
+      if (entry === "recollection") {
+        const sweep = await runtime.store.readSweepState("inbox");
+        await runtime.store.writeSweepState("inbox", { ...sweep, recollectionOffered: true });
+      }
+      runtime.store.appendEvent = async () => { throw new Error("event persistence failed"); };
+      const operation = entry === "card" ? domain.queueInstruction("inbox", before.id, "Inspect this item.")
+        : entry === "feed" ? domain.queueFeedInstruction("inbox", "Inspect the feed.")
+        : entry === "compound" ? domain.queueCompound("inbox")
+        : domain.requestSweepRecollection("inbox");
+      await expect(operation).rejects.toThrow("event persistence failed");
+      expect(await runtime.store.readWorkItems("inbox")).toEqual([]);
+      expect(await runtime.store.readCard("inbox", before.id)).toEqual(before);
+    } finally {
+      runtime.sqlite.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}
+
+test("notifications run after commit and are discarded on rollback", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "tend-after-commit-"));
+  const runtime = await createLocalRuntime(path.join(root, "data"), path.join(root, "attention.db"));
+  const observer = await createLocalRuntime(path.join(root, "data"), path.join(root, "attention.db"));
+  const observed: string[] = [];
+  try {
+    await runtime.store.serializeAtomic(async () => {
+      const card = await runtime.store.readCard("inbox", "inbox-ready-to-collect");
+      card.title = "Committed title";
+      await runtime.store.writeCard(card);
+      await runtime.store.afterCommit(async () => {
+        observed.push((await observer.store.readCard("inbox", card.id)).title);
+      });
+      expect(observed).toEqual([]);
+    });
+    expect(observed).toEqual(["Committed title"]);
+    await expect(runtime.store.serializeAtomic(async () => {
+      await runtime.store.afterCommit(async () => { observed.push("rolled back"); });
+      throw new Error("abort");
+    })).rejects.toThrow("abort");
+    expect(observed).toEqual(["Committed title"]);
+  } finally {
+    observer.sqlite.close();
+    runtime.sqlite.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Queue creation can leave a work item behind when a later card or event write fails. I made the queue entry points atomic and deferred agent notifications until after commit. Regression checks cover card, feed, compound, and recollection rollback plus notification visibility through a separate SQLite connection.
