### PR TITLE
fix(cleanup): reject overlapping cleanup for the same card

### DIFF
--- a/server/domain.ts
+++ b/server/domain.ts
@@ -660,6 +660,14 @@ function verifyMobileRiskConfirmation(
   }
 }
 
+function carriesCleanup(work: WorkItem): boolean {
+  return work.kind === "default_cleanup" || (work.kind === "execute_approved_action" && Boolean(work.completionCleanup));
+}
+
+function cleanupCompleted(work: WorkItem): boolean {
+  return work.status === "completed" && (work.kind === "default_cleanup" || work.postAction?.cleanup.status === "completed");
+}
+
 export class AttentionDomain {
   constructor(readonly store: AttentionStore) {}
 
@@ -1383,6 +1391,10 @@ export class AttentionDomain {
     requiredSourceMailbox(feedId, card, action);
     const approvalDigest = actionDigest(card, cardActionId);
     const feed = await this.store.readFeed(feedId);
+    if (feed.config.defaultCleanup && (await this.store.readWorkItems(feedId)).some((work) =>
+      work.cardId === cardId && work.kind === "default_cleanup"
+      && (work.status === "queued" || work.status === "working" || work.status === "approved_blocked")
+    )) throw new Error("Source cleanup is already pending for this card. Finish or cancel it before approving an action with cleanup.");
     const active = (await this.store.readWorkItems(feedId)).filter((work) =>
       work.cardId === cardId
       && work.kind === "execute_approved_action"
@@ -1446,6 +1458,10 @@ export class AttentionDomain {
     const config = await this.store.readConfig(feedId);
     const card = await this.store.readCard(feedId, cardId);
     const feedWork = await this.store.readWorkItems(feedId);
+    if (feedWork.some((work) =>
+      work.cardId === cardId && work.kind === "execute_approved_action" && work.completionCleanup
+      && (work.status === "queued" || work.status === "working" || work.status === "approved_blocked")
+    )) throw new Error("An approved action already includes this card's source cleanup.");
     const completedCleanup = feedWork.some((work) =>
       work.cardId === cardId
       && work.status === "completed"
@@ -2139,7 +2155,8 @@ export class AttentionDomain {
   async completeWork(feedId: string, workId: string, token: string, result: { response: string; blocks?: CardBlock[]; proposedAction?: ProposedAction; actions?: CardAction[]; done?: boolean; postAction?: PostActionCompletion }): Promise<WorkItem> {
     if (result.blocks) validateCardBlocks(result.blocks);
     validateCardActions(result.actions);
-    return this.store.serialize(async () => {
+    let staleError: Error | undefined;
+    const completed = await this.store.serializeAtomic(async () => {
       const work = await this.store.readWork(feedId, workId);
       if (work.status !== "working") throw new Error("Work item is not currently claimed.");
       if (work.capabilityToken !== token) throw new Error("Invalid scoped work capability token.");
@@ -2171,7 +2188,8 @@ export class AttentionDomain {
           await this.store.writeWork(work);
           await this.store.writeRoutineActionGroup(group);
           await this.store.appendEvent({ feedId, workId, type: "routine_action.stale", detail: { groupId: group.id } });
-          throw new Error(work.error);
+          staleError = new Error(work.error);
+          return work;
         }
         if (work.verifiedApprovalDigest !== work.approvalDigest) {
           throw new Error("Approved action must pass action:verify immediately before the external mutation.");
@@ -2205,7 +2223,8 @@ export class AttentionDomain {
           await this.store.writeWork(work);
           await this.store.writeCard(card);
           await this.store.appendEvent({ feedId, cardId: card.id, workId, type: "action.stale" });
-          throw new Error(work.error);
+          staleError = new Error(work.error);
+          return work;
         }
         if (
           (work.kind === "execute_approved_action" || work.kind === "default_cleanup") &&
@@ -2250,7 +2269,6 @@ export class AttentionDomain {
             type: "work.post_action_cleanup_blocked",
             detail: { response: work.response, postAction: result.postAction },
           });
-          if (work.claimedBy?.agent !== "claude") await this.maybeEmitClaudeWake(feedId, work, undefined, { includeDropped: true });
           return work;
         }
         const config = await this.store.readConfig(feedId);
@@ -2271,9 +2289,29 @@ export class AttentionDomain {
       work.response = result.response.trim();
       work.postAction = result.postAction;
       await this.store.writeWork(work);
+      await this.retireQueuedCleanup(work);
       await this.store.appendEvent({ feedId, cardId: work.cardId, workId, type: "work.completed", detail: { response: work.response, postAction: result.postAction } });
       return work;
     });
+    if (staleError) throw staleError;
+    if (completed.status === "approved_blocked" && completed.claimedBy?.agent !== "claude") {
+      await this.store.serialize(() => this.maybeEmitClaudeWake(feedId, completed, undefined, { includeDropped: true }));
+    }
+    return completed;
+  }
+
+  private async retireQueuedCleanup(completed: WorkItem): Promise<void> {
+    if (!cleanupCompleted(completed)) return;
+    for (const other of await this.store.readWorkItems(completed.feedId)) {
+      if (other.id === completed.id || other.cardId !== completed.cardId || other.status !== "queued" || !carriesCleanup(other)) continue;
+      other.status = "stale";
+      other.error = "Source cleanup was completed by another approved work item.";
+      other.verifiedAt = undefined;
+      other.verifiedApprovalDigest = undefined;
+      other.verifiedMailbox = undefined;
+      await this.store.writeWork(other);
+      await this.store.appendEvent({ feedId: other.feedId, cardId: other.cardId, workId: other.id, type: "action.stale", detail: { reason: other.error } });
+    }
   }
 
   async verifyApprovedAction(feedId: string, workId: string, token: string, authenticatedMailbox?: string): Promise<{ approvalDigest: string; action: ProposedAction; artifact?: CardBlock; verifiedMailbox?: string; completionCleanup?: string }> {
@@ -2282,6 +2320,15 @@ export class AttentionDomain {
       if (work.status !== "working") throw new Error("Approved action work must be claimed before verification.");
       if ((work.kind !== "execute_approved_action" && work.kind !== "default_cleanup" && work.kind !== "routine_action_batch") || !work.approvalDigest) throw new Error("Work item is not an approved action.");
       if (work.capabilityToken !== token) throw new Error("Invalid scoped work capability token.");
+      if (carriesCleanup(work)) {
+        const conflict = (await this.store.readWorkItems(feedId)).some((other) =>
+          other.id !== work.id && other.cardId === work.cardId && carriesCleanup(other) && (
+            other.status === "queued" || other.status === "working" || other.status === "approved_blocked" ||
+            (cleanupCompleted(other) && (other.completedAt ?? other.updatedAt) >= work.createdAt)
+          )
+        );
+        if (conflict) throw new Error("Conflicting source cleanup requires reconciliation before verification.");
+      }
       let result: { approvalDigest: string; action: ProposedAction; artifact?: CardBlock; verifiedMailbox?: string; completionCleanup?: string };
       if (work.kind === "routine_action_batch") {
         if (!work.routineActionGroupId) throw new Error("Routine action work is missing its group.");
@@ -2394,7 +2441,7 @@ export class AttentionDomain {
   }
 
   async reconcileApprovedWork(feedId: string, workId: string, token: string, result: { response: string; done?: boolean; postAction?: PostActionCompletion }): Promise<WorkItem> {
-    return this.store.serialize(async () => {
+    return this.store.serializeAtomic(async () => {
       const work = await this.store.readWork(feedId, workId);
       if (work.status !== "approved_blocked" || work.kind !== "execute_approved_action" || !work.approvalDigest) {
         throw new Error("Only a blocked approved action can be reconciled.");
@@ -2427,6 +2474,7 @@ export class AttentionDomain {
       work.error = undefined;
       await this.store.writeWork(work);
       await this.store.writeCard(card);
+      await this.retireQueuedCleanup(work);
       await this.store.appendEvent({ feedId, cardId: work.cardId, workId, type: "work.approved_action_reconciled", detail: { response: work.response, postAction: result.postAction } });
       return work;
     });

--- a/test/cleanup-deduplication.test.ts
+++ b/test/cleanup-deduplication.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import os from "node:os";
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import { AttentionDomain } from "../server/domain.ts";
+import { createLocalRuntime } from "../server/runtime.ts";
+
+test("bundled and standalone cleanup exclude each other", async () => {
+const root = await mkdtemp(path.join(os.tmpdir(), "domain-concurrent-cleanup-"));
+try {
+  const runtime = await createLocalRuntime(path.join(root, "data"), path.join(root, "attention.db"));
+  const domain = new AttentionDomain(runtime.store);
+  await domain.bindFeed("inbox", "thread-inbox");
+  await domain.upsertCard("inbox", {
+    id: "concurrent-cleanup",
+    title: "Send and archive",
+    why: "The approved action includes source cleanup.",
+    sourceMailbox: "owner@example.com",
+    blocks: [{ id: "draft", type: "editable_text", value: "Approved reply.", editable: true }],
+    actions: [
+      { id: "send", label: "Send", behavior: "approve_action", instruction: "Send the approved reply.", artifactBlockId: "draft", externalMutation: true, mailboxPolicy: "reply_from_source" },
+      { id: "archive", label: "Archive", behavior: "default_cleanup" },
+    ],
+  });
+  const cleanup = await domain.queueSourceCleanup("inbox", "concurrent-cleanup");
+  await expect(domain.runCardAction("inbox", "concurrent-cleanup", "send")).rejects.toThrow("Source cleanup is already pending");
+  await domain.cancelQueuedWork("inbox", cleanup.id);
+  await domain.runCardAction("inbox", "concurrent-cleanup", "send");
+  await expect(domain.queueSourceCleanup("inbox", "concurrent-cleanup")).rejects.toThrow("already includes");
+  runtime.sqlite.close();
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+});
+
+for (const duplicateStatus of ["queued", "working", "approved_blocked"] as const) {
+  test(`legacy ${duplicateStatus} cleanup is retired or kept for reconciliation`, async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "tend-legacy-cleanup-"));
+    const runtime = await createLocalRuntime(path.join(root, "data"), path.join(root, "attention.db"));
+    try {
+      const domain = new AttentionDomain(runtime.store);
+      await domain.bindFeed("inbox", "thread-inbox");
+      await domain.upsertCard("inbox", {
+        id: "legacy-card", title: "Archive this", why: "Cleanup fixture",
+        blocks: [], actions: [{ id: "archive", label: "Archive", behavior: "default_cleanup" }],
+      });
+      const queued = await domain.queueSourceCleanup("inbox", "legacy-card");
+      const claim = await domain.claimWork("inbox", "thread-inbox");
+      if (!claim || !("capabilityToken" in claim)) throw new Error("Expected a work claim");
+      await domain.verifyApprovedAction("inbox", queued.id, claim.capabilityToken);
+      const duplicate = { ...await runtime.store.readWork("inbox", queued.id), id: "legacy-duplicate", status: duplicateStatus };
+      await runtime.store.writeWork(duplicate);
+      await domain.completeWork("inbox", queued.id, claim.capabilityToken, { response: "Cleanup confirmed." });
+      const remaining = await runtime.store.readWork("inbox", duplicate.id);
+      expect(remaining.status).toBe(duplicateStatus === "queued" ? "stale" : duplicateStatus);
+      if (duplicateStatus === "queued") {
+        expect(remaining.verifiedApprovalDigest).toBeUndefined();
+      } else if (duplicateStatus === "working") {
+        await expect(domain.verifyApprovedAction("inbox", remaining.id, remaining.capabilityToken)).rejects.toThrow("Conflicting source cleanup");
+      }
+    } finally {
+      runtime.sqlite.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
A card can queue standalone cleanup while an approved action already includes that cleanup. I reject both queue orders, retire older queued duplicates after confirmed cleanup, and reject fresh verification of conflicting active work. Existing working or blocked items remain visible for reconciliation because they may already have touched the source.
