### PR TITLE
fix(mobile): isolate cloud sync in temporary homes

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,7 +36,11 @@ pnpm tend:package
 
 ## Local Runtime
 
-Use `ATTENTION_HOME` to keep development data separate:
+Use `ATTENTION_HOME` to keep development data separate.
+Mobile synchronization defaults to off for a non-default home, including inherited cloud credentials.
+Set `TEND_MOBILE_SYNC=1` only when that home should synchronize with the configured cloud account; `TEND_MOBILE_SYNC=0` disables it for any home.
+
+Start an isolated runtime:
 
 ```sh
 ATTENTION_HOME=.local-tend pnpm tend -- start --foreground

--- a/scripts/smoke-binary.ts
+++ b/scripts/smoke-binary.ts
@@ -229,7 +229,17 @@ async function cliText(args: string[]): Promise<string> {
 }
 
 function runtimeEnv() {
-  return { ...process.env, ATTENTION_HOME: home, ATTENTION_API_PORT: port };
+  return {
+    ...process.env,
+    ATTENTION_HOME: home,
+    ATTENTION_API_PORT: port,
+    TEND_MOBILE_SYNC: "0",
+    TEND_MOBILE_ENV_FILE: "",
+    TEND_MOBILE_SUPABASE_URL: "",
+    TEND_MOBILE_SUPABASE_SECRET_KEY: "",
+    TEND_MOBILE_USER_ID: "",
+    TEND_MOBILE_WORKER_ID: "",
+  };
 }
 
 async function waitForStatus(): Promise<{

--- a/server/mobile/client.ts
+++ b/server/mobile/client.ts
@@ -33,7 +33,14 @@ const mobileEnvKeys = [
   "TEND_MOBILE_WORKER_ID",
 ] as const;
 
+function mobileSyncEnabled(env: NodeJS.ProcessEnv): boolean {
+  if (env.TEND_MOBILE_SYNC === "0") return false;
+  if (env.TEND_MOBILE_SYNC === "1") return true;
+  return env.ATTENTION_HOME === undefined || path.resolve(env.ATTENTION_HOME) === path.join(homedir(), ".attention");
+}
+
 export function loadMobileCloudEnvFile(env: NodeJS.ProcessEnv = process.env): void {
+  if (!mobileSyncEnabled(env)) return;
   const configuredPath = env.TEND_MOBILE_ENV_FILE?.trim();
   const configRoot = env.XDG_CONFIG_HOME?.trim() || path.join(homedir(), ".config");
   const envFile = configuredPath || path.join(configRoot, "tend", "mobile.env");
@@ -69,6 +76,7 @@ export function loadMobileCloudEnvFile(env: NodeJS.ProcessEnv = process.env): vo
 }
 
 export function mobileCloudConfigFromEnv(env: NodeJS.ProcessEnv = process.env): MobileCloudConfig | null {
+  if (!mobileSyncEnabled(env)) return null;
   const url = env.TEND_MOBILE_SUPABASE_URL?.trim();
   const secretKey = env.TEND_MOBILE_SUPABASE_SECRET_KEY?.trim();
   const userId = env.TEND_MOBILE_USER_ID?.trim();

--- a/test/mobile-home-isolation.test.ts
+++ b/test/mobile-home-isolation.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { loadMobileCloudEnvFile, mobileCloudConfigFromEnv } from "../server/mobile/client";
+
+test("isolated homes require explicit mobile sync opt-in", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "tend-mobile-config-"));
+  try {
+    const file = path.join(root, "tend", "mobile.env");
+    await mkdir(path.dirname(file));
+    await writeFile(file, "TEND_MOBILE_SUPABASE_URL=https://fixture.invalid\nTEND_MOBILE_SUPABASE_SECRET_KEY=fixture\nTEND_MOBILE_USER_ID=user\nTEND_MOBILE_WORKER_ID=worker\n", { mode: 0o600 });
+    const canonical: NodeJS.ProcessEnv = { XDG_CONFIG_HOME: root };
+    loadMobileCloudEnvFile(canonical);
+    expect(mobileCloudConfigFromEnv(canonical)?.userId).toBe("user");
+    expect(mobileCloudConfigFromEnv({ ...canonical, ATTENTION_HOME: "" })).toBeNull();
+    const isolated: NodeJS.ProcessEnv = { XDG_CONFIG_HOME: root, ATTENTION_HOME: path.join(root, "home") };
+    loadMobileCloudEnvFile(isolated);
+    expect(mobileCloudConfigFromEnv(isolated)).toBeNull();
+    Object.assign(isolated, canonical);
+    expect(mobileCloudConfigFromEnv(isolated)).toBeNull();
+    isolated.TEND_MOBILE_SYNC = "1";
+    isolated.TEND_MOBILE_ENV_FILE = file;
+    loadMobileCloudEnvFile(isolated);
+    expect(mobileCloudConfigFromEnv(isolated)?.userId).toBe("user");
+    isolated.TEND_MOBILE_SYNC = "0";
+    expect(mobileCloudConfigFromEnv(isolated)).toBeNull();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
A temporary ATTENTION_HOME can load the regular mobile configuration and synchronize test data to the configured account. I made cloud sync opt in for nondefault homes, including when credentials are inherited, and disabled it explicitly in the binary smoke test. The regression check covers default configuration, isolated homes, explicit opt in, and explicit disable.
