### PR TITLE
fix(locks): release process locks after a crash

### DIFF
--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -67,3 +67,12 @@ Import first copies the backup into a temporary staging directory. Tend refuses 
 the same runtime home is active, then swaps the staged database and data into place with rollback if
 the swap fails. Older data-directory-only backups are still accepted; the next local runtime start
 rehydrates `attention.db` from those imported file mirrors.
+
+## Process locks
+
+Service commands, mutations, and agent wake writes use separate SQLite lock files whose operating-system locks end when the owning process exits.
+An empty marker file at the old lock path prevents older binaries from entering the same critical section.
+Keep the marker and SQLite files in place; deleting a lock file can let processes lock different files at the same path.
+Stop all older Tend processes before upgrading this lock format.
+If an ownerless legacy `attention.lock`, `data/.mutation-lock`, or `data/.agent-wake-lock` directory remains, the command reports its exact path and refuses to reclaim it automatically.
+Remove that directory only after confirming no older process is using the home.

--- a/server/cli/service.ts
+++ b/server/cli/service.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { attentionDataDir, attentionHome, attentionLogDir } from "../paths";
+import { withProcessLock } from "../processLock";
 import { apiPort, apiUrl, print } from "./shared";
 
 export async function startBackgroundCommand(): Promise<void> {
@@ -155,17 +156,7 @@ async function checkUrl(url: string): Promise<boolean> {
 }
 
 async function withServiceLock(callback: () => Promise<void>): Promise<void> {
-  await mkdir(attentionHome(), { recursive: true });
-  try {
-    await mkdir(lockDir());
-  } catch {
-    throw new Error("Another Tend service command is already running.");
-  }
-  try {
-    await callback();
-  } finally {
-    await rm(lockDir(), { recursive: true, force: true });
-  }
+  await withProcessLock(lockDir(), callback, 0);
 }
 
 type ServicePidRecord = {

--- a/server/processLock.ts
+++ b/server/processLock.ts
@@ -1,0 +1,35 @@
+import { Database } from "bun:sqlite";
+import { lstat, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export async function withProcessLock<T>(legacyPath: string, callback: () => Promise<T>, timeoutMs = 6_000): Promise<T> {
+  await mkdir(path.dirname(legacyPath), { recursive: true });
+  const db = new Database(`${legacyPath}.sqlite`, { create: true });
+  const deadline = Date.now() + timeoutMs;
+  try {
+    db.exec("PRAGMA busy_timeout = 0;");
+    while (true) {
+      try {
+        db.exec("BEGIN IMMEDIATE;");
+        break;
+      } catch (error) {
+        const code = (error as { code?: string }).code;
+        if (code !== "SQLITE_BUSY" && code !== "SQLITE_LOCKED") throw error;
+        if (Date.now() >= deadline) throw new Error(`Timed out waiting for the process lock at ${legacyPath}.`);
+        await new Promise((resolve) => setTimeout(resolve, 15));
+      }
+    }
+    try {
+      await writeFile(legacyPath, "", { flag: "wx" });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      const entry = await lstat(legacyPath);
+      if (!entry.isFile() || entry.size !== 0) {
+        throw new Error(`Legacy lock exists at ${legacyPath}. Stop all older Tend processes and remove the abandoned lock before retrying.`);
+      }
+    }
+    return await callback();
+  } finally {
+    db.close();
+  }
+}

--- a/server/store.ts
+++ b/server/store.ts
@@ -43,6 +43,7 @@ import {
   threadBinding,
 } from "./templates";
 import { isoNow, makeId, readJson, withMutationLock, writeJson, writeText } from "./util";
+import { withProcessLock } from "./processLock";
 import { defaultDictationCapability } from "./monologue";
 import { FileCardRepository, type CardRepository } from "./repositories/cards";
 import { FileFeedEventRepository, type FeedEventRepository } from "./repositories/feedEvents";
@@ -633,22 +634,7 @@ export class AttentionStore {
   }
 
   private async withAgentWakeLock<T>(callback: () => Promise<T>): Promise<T> {
-    // The domain currently serializes wake-producing mutations; keep this file lock for future non-serialized callers.
-    const lockPath = this.path(".agent-wake-lock");
-    for (let attempt = 0; attempt < 400; attempt += 1) {
-      try {
-        await mkdir(lockPath);
-        try {
-          return await callback();
-        } finally {
-          await rm(lockPath, { recursive: true, force: true });
-        }
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-        await new Promise((resolve) => setTimeout(resolve, 15));
-      }
-    }
-    throw new Error("Timed out waiting for the agent wake lock.");
+    return withProcessLock(this.path(".agent-wake-lock"), callback);
   }
 
   private agentPath(agent: AgentPresence["agent"], ...parts: string[]): string {

--- a/server/util.ts
+++ b/server/util.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { withProcessLock } from "./processLock";
 
 export const isoNow = () => new Date().toISOString();
 export const makeId = (prefix: string) => `${prefix}_${randomUUID()}`;
@@ -15,23 +16,7 @@ export function safeIdentifier(value: string, label: string): string {
 }
 
 export async function withMutationLock<T>(dataDir: string, callback: () => Promise<T>): Promise<T> {
-  await mkdir(dataDir, { recursive: true });
-  const lockPath = join(dataDir, ".mutation-lock");
-  for (let attempt = 0; attempt < 400; attempt += 1) {
-    try {
-      await mkdir(lockPath);
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      if (attempt === 399) throw new Error("Timed out waiting for the filesystem mutation lock.");
-      await new Promise((resolve) => setTimeout(resolve, 15));
-    }
-  }
-  try {
-    return await callback();
-  } finally {
-    await rm(lockPath, { recursive: true, force: true });
-  }
+  return withProcessLock(join(dataDir, ".mutation-lock"), callback);
 }
 
 export async function readJson<T>(path: string): Promise<T> {

--- a/test/fixtures/hold-process-lock.ts
+++ b/test/fixtures/hold-process-lock.ts
@@ -1,0 +1,6 @@
+import { withProcessLock } from "../../server/processLock";
+
+await withProcessLock(process.argv[2]!, async () => {
+  console.log("locked");
+  await Bun.sleep(60_000);
+});

--- a/test/process-lock.test.ts
+++ b/test/process-lock.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { withProcessLock } from "../server/processLock";
+
+test("a live holder excludes competitors and process death releases ownership", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "tend-process-lock-"));
+  const lock = path.join(root, "lock");
+  const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "fixtures", "hold-process-lock.ts"), lock], { stdout: "pipe", stderr: "pipe" });
+  try {
+    const reader = child.stdout.getReader();
+    const ready = await reader.read();
+    expect(new TextDecoder().decode(ready.value)).toContain("locked");
+    await expect(mkdir(lock)).rejects.toMatchObject({ code: "EEXIST" });
+    reader.releaseLock();
+    await expect(withProcessLock(lock, async () => "unexpected", 30)).rejects.toThrow("Timed out");
+    child.kill("SIGKILL");
+    await child.exited;
+    expect(await withProcessLock(lock, async () => "recovered", 30)).toBe("recovered");
+    await expect(withProcessLock(lock, async () => { throw new Error("callback failed"); })).rejects.toThrow("callback failed");
+    expect(await withProcessLock(lock, async () => "released")).toBe("released");
+  } finally {
+    child.kill();
+    await child.exited;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("ownerless legacy locks are not mistaken for dead processes", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "tend-legacy-lock-"));
+  try {
+    const lock = path.join(root, "lock");
+    await mkdir(lock);
+    await expect(withProcessLock(lock, async () => "unexpected")).rejects.toThrow("Stop all older Tend processes");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
A killed process leaves directory locks behind and blocks later mutations or service commands. I replaced the service, mutation, and agent wake locks with SQLite locks that the operating system releases when the holder exits. The process test confirms exclusion while a holder is alive and recovery after SIGKILL; legacy directory locks still require checking that older processes have stopped before removal.
