### PR TITLE
fix(ui): render validated video cards

### DIFF
--- a/server/domain.ts
+++ b/server/domain.ts
@@ -532,7 +532,7 @@ function isSafeCardHref(value: string): boolean {
   if (value.startsWith("/api/artifacts/")) return true;
   try {
     const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
+    return (url.protocol === "http:" || url.protocol === "https:") && !url.username && !url.password;
   } catch {
     return false;
   }
@@ -569,7 +569,7 @@ function validateListBlock(block: Record<string, unknown>, index: number): void 
         throw new Error(`${blockDescription(block, index)} item ${itemIndex + 1} may use \`href\` only in an evidence block.`);
       }
       if (!hasText(item.href) || !isSafeCardHref(item.href)) {
-        throw new Error(`${blockDescription(block, index)} item ${itemIndex + 1} needs an http(s) or local artifact \`href\`.`);
+        throw new Error(`${blockDescription(block, index)} item ${itemIndex + 1} needs an http(s) \`href\` without embedded credentials, or a local artifact \`href\`.`);
       }
     }
   }
@@ -651,7 +651,7 @@ function validateCardBlocks(blocks: unknown): asserts blocks is CardBlock[] {
           throw new Error(`${blockDescription(block, index)} needs \`video.title\` and \`video.href\` strings.`);
         }
         if (!isSafeCardHref(block.video.href)) {
-          throw new Error(`${blockDescription(block, index)} needs an http(s) \`video.href\`.`);
+          throw new Error(`${blockDescription(block, index)} needs an http(s) \`video.href\` without embedded credentials.`);
         }
         break;
       case "chart":

--- a/server/domain.ts
+++ b/server/domain.ts
@@ -650,6 +650,9 @@ function validateCardBlocks(blocks: unknown): asserts blocks is CardBlock[] {
         if (!isRecord(block.video) || !hasText(block.video.title) || !hasText(block.video.href)) {
           throw new Error(`${blockDescription(block, index)} needs \`video.title\` and \`video.href\` strings.`);
         }
+        if (!isSafeCardHref(block.video.href)) {
+          throw new Error(`${blockDescription(block, index)} needs an http(s) \`video.href\`.`);
+        }
         break;
       case "chart":
         if (!isRecord(block.chart) || typeof block.chart.max !== "number" || !Number.isFinite(block.chart.max) || block.chart.max <= 0) {

--- a/src/feed/CardView.tsx
+++ b/src/feed/CardView.tsx
@@ -87,6 +87,41 @@ function CardHistory({ card }: { card: Card }) {
   );
 }
 
+function safeVideoHref(href: string): string | null {
+  try {
+    const url = new URL(href);
+    return url.protocol === "http:" || url.protocol === "https:" ? href : null;
+  } catch {
+    return null;
+  }
+}
+
+function videoEmbedUrl(href: string): string | null {
+  try {
+    const url = new URL(href);
+    if (url.protocol !== "https:") return null;
+    if (url.hostname === "www.loom.com" && url.pathname.startsWith("/share/")) {
+      const id = url.pathname.slice("/share/".length).split("/")[0];
+      return id && /^[a-zA-Z0-9_-]+$/.test(id) ? `https://www.loom.com/embed/${id}` : null;
+    }
+    if (url.hostname === "youtu.be") {
+      const id = url.pathname.slice(1);
+      return id && /^[a-zA-Z0-9_-]+$/.test(id) ? `https://www.youtube.com/embed/${id}` : null;
+    }
+    if ((url.hostname === "www.youtube.com" || url.hostname === "youtube.com") && url.pathname === "/watch") {
+      const id = url.searchParams.get("v");
+      return id && /^[a-zA-Z0-9_-]+$/.test(id) ? `https://www.youtube.com/embed/${id}` : null;
+    }
+    if (url.hostname === "drive.google.com") {
+      const match = url.pathname.match(/^\/file\/d\/([a-zA-Z0-9_-]+)(?:\/|$)/);
+      return match ? `https://drive.google.com/file/d/${match[1]}/preview` : null;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
 function Block({ feedId, cardId, block, onChanged }: { feedId: string; cardId: string; block: CardBlock; onChanged: () => void }) {
   const [value, setValue] = useState(block.value ?? "");
   useEffect(() => setValue(block.value ?? ""), [block.value]);
@@ -145,6 +180,29 @@ function Block({ feedId, cardId, block, onChanged }: { feedId: string; cardId: s
             </div>
           )}
         </div>
+      </section>
+    );
+  }
+  if (block.type === "video" && block.video) {
+    const href = safeVideoHref(block.video.href);
+    const embedUrl = href ? videoEmbedUrl(href) : null;
+    return (
+      <section className="block block-video">
+        {block.label && <h3>{block.label}</h3>}
+        {embedUrl && (
+          <div className="video-frame">
+            <iframe
+              src={embedUrl}
+              title={block.video.title}
+              loading="lazy"
+              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+              allowFullScreen
+            />
+          </div>
+        )}
+        {href
+          ? <DetachedLink className="video-link" href={href}>Open video: {block.video.title}</DetachedLink>
+          : <span className="video-link">Video link unavailable</span>}
       </section>
     );
   }

--- a/src/feed/CardView.tsx
+++ b/src/feed/CardView.tsx
@@ -90,7 +90,9 @@ function CardHistory({ card }: { card: Card }) {
 function safeVideoHref(href: string): string | null {
   try {
     const url = new URL(href);
-    return url.protocol === "http:" || url.protocol === "https:" ? href : null;
+    return (url.protocol === "http:" || url.protocol === "https:") && !url.username && !url.password
+      ? url.href
+      : null;
   } catch {
     return null;
   }
@@ -106,11 +108,11 @@ function videoEmbedUrl(href: string): string | null {
     }
     if (url.hostname === "youtu.be") {
       const id = url.pathname.slice(1);
-      return id && /^[a-zA-Z0-9_-]+$/.test(id) ? `https://www.youtube.com/embed/${id}` : null;
+      return id && /^[a-zA-Z0-9_-]+$/.test(id) ? `https://www.youtube-nocookie.com/embed/${id}` : null;
     }
     if ((url.hostname === "www.youtube.com" || url.hostname === "youtube.com") && url.pathname === "/watch") {
       const id = url.searchParams.get("v");
-      return id && /^[a-zA-Z0-9_-]+$/.test(id) ? `https://www.youtube.com/embed/${id}` : null;
+      return id && /^[a-zA-Z0-9_-]+$/.test(id) ? `https://www.youtube-nocookie.com/embed/${id}` : null;
     }
     if (url.hostname === "drive.google.com") {
       const match = url.pathname.match(/^\/file\/d\/([a-zA-Z0-9_-]+)(?:\/|$)/);
@@ -195,7 +197,9 @@ function Block({ feedId, cardId, block, onChanged }: { feedId: string; cardId: s
               src={embedUrl}
               title={block.video.title}
               loading="lazy"
-              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+              sandbox="allow-scripts allow-same-origin allow-presentation"
+              referrerPolicy="no-referrer"
+              allow="encrypted-media; picture-in-picture; fullscreen"
               allowFullScreen
             />
           </div>

--- a/test/card-render.test.tsx
+++ b/test/card-render.test.tsx
@@ -90,7 +90,9 @@ test("renders supported videos inline and keeps their source link detached", () 
   };
 
   const html = renderToStaticMarkup(<CardView card={card} active={false} onActivate={() => {}} onChanged={() => {}} onAction={() => {}} onReturnToReview={() => {}} />);
-  expect(html).toContain('src="https://www.youtube.com/embed/abc_123-XYZ"');
+  expect(html).toContain('src="https://www.youtube-nocookie.com/embed/abc_123-XYZ"');
+  expect(html).toContain('sandbox="allow-scripts allow-same-origin allow-presentation"');
+  expect(html).toContain('referrerPolicy="no-referrer"');
   expect(html).toContain('href="https://youtu.be/abc_123-XYZ"');
   expect(html).toContain('target="_blank"');
   expect(html).toContain("Open video: Product walkthrough");
@@ -111,6 +113,21 @@ test("links unsupported video providers without embedding them", () => {
   expect(html).toContain('href="https://video.example.test/watch/123"');
 });
 
+test("does not embed lookalike provider hosts", () => {
+  const card: Card = {
+    id: "lookalike-video", feedId: "company-attention", kind: "attention", status: "to_review_new",
+    title: "Open this video", eyebrow: "Video", why: "Only exact provider hosts may be embedded.",
+    blocks: [{ id: "video", type: "video", video: {
+      title: "Untrusted recording", href: "https://www.youtube.com.example.test/watch?v=abc_123-XYZ",
+    } }],
+    readyForPass: 1, createdAt: "2026-09-12T12:00:00.000Z", updatedAt: "2026-09-12T12:00:00.000Z", history: [],
+  };
+
+  const html = renderToStaticMarkup(<CardView card={card} active={false} onActivate={() => {}} onChanged={() => {}} onAction={() => {}} onReturnToReview={() => {}} />);
+  expect(html).not.toContain("<iframe");
+  expect(html).toContain('href="https://www.youtube.com.example.test/watch?v=abc_123-XYZ"');
+});
+
 test("does not render an unsafe legacy video link", () => {
   const card: Card = {
     id: "unsafe-video", feedId: "company-attention", kind: "attention", status: "to_review_new",
@@ -121,6 +138,20 @@ test("does not render an unsafe legacy video link", () => {
 
   const html = renderToStaticMarkup(<CardView card={card} active={false} onActivate={() => {}} onChanged={() => {}} onAction={() => {}} onReturnToReview={() => {}} />);
   expect(html).not.toContain("javascript:");
+  expect(html).toContain("Video link unavailable");
+});
+
+test("does not render a legacy video URL containing credentials", () => {
+  const card: Card = {
+    id: "credential-video", feedId: "company-attention", kind: "attention", status: "to_review_new",
+    title: "Unsafe video", eyebrow: "Video", why: "Credentials must not travel in card links.",
+    blocks: [{ id: "video", type: "video", video: { title: "Unsafe", href: "https://user:secret@youtu.be/abc_123-XYZ" } }],
+    readyForPass: 1, createdAt: "2026-09-12T12:00:00.000Z", updatedAt: "2026-09-12T12:00:00.000Z", history: [],
+  };
+
+  const html = renderToStaticMarkup(<CardView card={card} active={false} onActivate={() => {}} onChanged={() => {}} onAction={() => {}} onReturnToReview={() => {}} />);
+  expect(html).not.toContain("<iframe");
+  expect(html).not.toContain("secret");
   expect(html).toContain("Video link unavailable");
 });
 

--- a/test/card-render.test.tsx
+++ b/test/card-render.test.tsx
@@ -79,6 +79,51 @@ test("renders the imported wide card image inline with a separate editable note"
   expect(html).toContain("What do you think?");
 });
 
+test("renders supported videos inline and keeps their source link detached", () => {
+  const card: Card = {
+    id: "video-card", feedId: "company-attention", kind: "attention", status: "to_review_new",
+    title: "Watch this", eyebrow: "Video", why: "The source is easier to review in place.",
+    blocks: [{ id: "video", type: "video", label: "Demo", video: {
+      title: "Product walkthrough", href: "https://youtu.be/abc_123-XYZ",
+    } }],
+    readyForPass: 1, createdAt: "2026-09-12T12:00:00.000Z", updatedAt: "2026-09-12T12:00:00.000Z", history: [],
+  };
+
+  const html = renderToStaticMarkup(<CardView card={card} active={false} onActivate={() => {}} onChanged={() => {}} onAction={() => {}} onReturnToReview={() => {}} />);
+  expect(html).toContain('src="https://www.youtube.com/embed/abc_123-XYZ"');
+  expect(html).toContain('href="https://youtu.be/abc_123-XYZ"');
+  expect(html).toContain('target="_blank"');
+  expect(html).toContain("Open video: Product walkthrough");
+});
+
+test("links unsupported video providers without embedding them", () => {
+  const card: Card = {
+    id: "linked-video", feedId: "company-attention", kind: "attention", status: "to_review_new",
+    title: "Open this video", eyebrow: "Video", why: "Unknown providers should not become iframes.",
+    blocks: [{ id: "video", type: "video", video: {
+      title: "Private recording", href: "https://video.example.test/watch/123",
+    } }],
+    readyForPass: 1, createdAt: "2026-09-12T12:00:00.000Z", updatedAt: "2026-09-12T12:00:00.000Z", history: [],
+  };
+
+  const html = renderToStaticMarkup(<CardView card={card} active={false} onActivate={() => {}} onChanged={() => {}} onAction={() => {}} onReturnToReview={() => {}} />);
+  expect(html).not.toContain("<iframe");
+  expect(html).toContain('href="https://video.example.test/watch/123"');
+});
+
+test("does not render an unsafe legacy video link", () => {
+  const card: Card = {
+    id: "unsafe-video", feedId: "company-attention", kind: "attention", status: "to_review_new",
+    title: "Unsafe legacy video", eyebrow: "Video", why: "Old stored data still needs a rendering boundary.",
+    blocks: [{ id: "video", type: "video", video: { title: "Unsafe", href: "javascript:alert(1)" } }],
+    readyForPass: 1, createdAt: "2026-09-12T12:00:00.000Z", updatedAt: "2026-09-12T12:00:00.000Z", history: [],
+  };
+
+  const html = renderToStaticMarkup(<CardView card={card} active={false} onActivate={() => {}} onChanged={() => {}} onAction={() => {}} onReturnToReview={() => {}} />);
+  expect(html).not.toContain("javascript:");
+  expect(html).toContain("Video link unavailable");
+});
+
 test("renders a visible lens receipt for a context-influenced card", () => {
   const card: Card = {
     id: "paywall-context",

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -1822,6 +1822,12 @@ describe("filesystem workspace", () => {
       why: "Receipt links need markdown text.",
       blocks: [{ id: "receipt", type: "receipt", label: "Source", url: "https://example.com/agreement" } as any],
     })).rejects.toThrow("Markdown link syntax");
+    await expect(domain.upsertCard("company-attention", {
+      id: "unsafe-video-url",
+      title: "Unsafe video",
+      why: "Video links must not execute script URLs.",
+      blocks: [{ id: "video", type: "video", video: { title: "Unsafe", href: "javascript:alert(1)" } }],
+    })).rejects.toThrow("http(s)");
   });
 
   test("requires email thread blocks to contain the full source message", async () => {

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -1803,7 +1803,13 @@ describe("filesystem workspace", () => {
       title: "Unsafe source",
       why: "Private paths must not become feed links.",
       blocks: [{ id: "sources", type: "evidence", items: [{ label: "Local file", href: "file:///Users/danshipper/private.pdf" }] }],
-    })).rejects.toThrow("http(s) or local artifact");
+    })).rejects.toThrow("http(s)");
+    await expect(domain.upsertCard("company-attention", {
+      id: "credential-evidence-link",
+      title: "Unsafe source",
+      why: "Credentials must not travel in source links.",
+      blocks: [{ id: "sources", type: "evidence", items: [{ label: "Private source", href: "https://user:secret@example.com/source" }] }],
+    })).rejects.toThrow("without embedded credentials");
     await expect(domain.upsertCard("company-attention", {
       id: "checklist-link",
       title: "Checklist link",
@@ -1827,6 +1833,12 @@ describe("filesystem workspace", () => {
       title: "Unsafe video",
       why: "Video links must not execute script URLs.",
       blocks: [{ id: "video", type: "video", video: { title: "Unsafe", href: "javascript:alert(1)" } }],
+    })).rejects.toThrow("http(s)");
+    await expect(domain.upsertCard("company-attention", {
+      id: "credential-video-url",
+      title: "Unsafe video",
+      why: "Video links must not contain embedded credentials.",
+      blocks: [{ id: "video", type: "video", video: { title: "Unsafe", href: "https://user:secret@youtu.be/abc_123-XYZ" } }],
     })).rejects.toThrow("http(s)");
   });
 


### PR DESCRIPTION
Tend already accepts video blocks, but the current card component silently renders them as blank content after the renderer split. This restores allowlisted inline embeds for YouTube, Loom, and Google Drive, keeps a detached source link, and falls back to a link for other web providers.

Security review tightened the browser boundary before merge: exact-host embeds are sandboxed, send no referrer, YouTube uses its privacy-enhanced host, lookalike providers remain link-only, and URL credentials plus non-HTTP(S) schemes are rejected in both validation and legacy rendering.

Validation:
- `pnpm check` (442 passed, 1 optional local-Supabase test skipped)
- `pnpm build`
- `pnpm audit --prod --audit-level high` (no known vulnerabilities)
