### PR TITLE
fix(approvals): migrate legacy mailbox digests

### DIFF
--- a/server/domain.ts
+++ b/server/domain.ts
@@ -68,7 +68,7 @@ import { agentPresenceLiveness, AttentionStore, FEED_PROMPT_NAMES, readingAttent
 import { demoCards, feedConfig } from "./templates";
 import { detectMonologue } from "./monologue";
 import { digest, isoNow, makeId, makeToken, safeIdentifier, slugify } from "./util";
-import { actionDigest, cleanupDigest, configuredApprovalAction, requiredSourceMailbox, routineActionDigest, verifySourceMailbox } from "./workflow/approvals";
+import { actionDigest, cleanupDigest, configuredApprovalAction, legacyActionDigestWithoutSourceMailbox, requiredSourceMailbox, routineActionDigest, verifySourceMailbox } from "./workflow/approvals";
 import { prepareApprovedEmailDelivery, validateEmailDeliveryReadback } from "./workflow/emailDelivery";
 import { queuedWork } from "./workflow/workItems";
 import { hasVoiceApprovalCandidate, matchExplicitVoiceApproval } from "./workflow/voiceApprovals";
@@ -1442,6 +1442,24 @@ export class AttentionDomain {
   private async assertCardSourceCurrent(card: Card): Promise<void> {
     if (!card.sourceRunIds?.length) return;
     await this.assertSourceRunIdsCurrent(card.feedId, card.sourceRunIds, card);
+  }
+
+  private async migrateLegacyMailboxApproval(work: WorkItem, card: Card): Promise<{ from: string; to: string } | null> {
+    if (!card.sourceRunIds?.length) return null;
+    const legacyDigest = legacyActionDigestWithoutSourceMailbox(card, work.cardActionId);
+    const currentDigest = actionDigest(card, work.cardActionId);
+    if (!legacyDigest || legacyDigest === currentDigest || work.approvalDigest !== legacyDigest) return null;
+    const contentChangedAfterApproval = (await this.store.readEvents(card.feedId)).some((event) =>
+      event.cardId === card.id
+      && event.at >= work.createdAt
+      && (event.type === "card.updated" || event.type === "card.block_edited")
+    );
+    if (contentChangedAfterApproval) return null;
+    await this.assertCardSourceCurrent(card);
+    const from = work.approvalDigest;
+    work.approvalDigest = currentDigest;
+    clearActionVerification(work);
+    return { from, to: currentDigest };
   }
 
   private async quarantineLegacyMutationWork(feed: FeedView, work: WorkItem): Promise<boolean> {
@@ -3019,15 +3037,29 @@ export class AttentionDomain {
     let staleError: Error | undefined;
     const retried = await this.store.serializeAtomic(async () => {
       const work = await this.store.readWork(feedId, workId);
-      if ((work.status !== "approved_blocked" && work.status !== "failed") || work.kind !== "execute_approved_action" || !work.approvalDigest) {
+      const migrationStale = work.status === "stale" && work.error === "Approval stale - the proposed action or artifact changed after approval.";
+      if ((work.status !== "approved_blocked" && work.status !== "failed" && !migrationStale) || work.kind !== "execute_approved_action" || !work.approvalDigest) {
         throw new Error("Only an approved blocked action can be retried.");
       }
       if (work.postAction?.cleanup.status === "blocked") {
         throw new Error("The main action already succeeded. Retry only the bundled cleanup, then use work:reconcile-approved.");
       }
       const card = await this.store.readCard(feedId, work.cardId);
+      const newerCompletedAction = (await this.store.readWorkItems(feedId)).some((other) =>
+        other.id !== work.id
+        && other.cardId === work.cardId
+        && other.kind === "execute_approved_action"
+        && other.cardActionId === work.cardActionId
+        && other.status === "completed"
+        && other.createdAt > work.createdAt
+      );
+      if (newerCompletedAction) throw new Error("A newer approval already completed this card action; the older action cannot be retried.");
       requiredSourceMailbox(feedId, card, configuredApprovalAction(card, work.cardActionId));
+      let migration: { from: string; to: string } | null = null;
       if (work.approvalDigest !== actionDigest(card, work.cardActionId)) {
+        migration = await this.migrateLegacyMailboxApproval(work, card);
+      }
+      if (work.approvalDigest !== actionDigest(card, work.cardActionId) || (migrationStale && !migration)) {
         work.status = "stale";
         work.error = "Approval stale - the proposed action or artifact changed after approval.";
         clearActionVerification(work);
@@ -3042,10 +3074,20 @@ export class AttentionDomain {
       }
       this.requeueWorkItem(work);
       card.status = "queued";
+      if (migration) appendHistory(card, "system.approval_digest_migrated", work.id);
       appendHistory(card, "codex.approved_action_retry_queued", work.id);
       await this.persistQueuedWork(feedId, work, {
         afterWrite: async () => {
           await this.store.writeCard(card);
+          if (migration) {
+            await this.store.appendEvent({
+              feedId,
+              cardId: work.cardId,
+              workId,
+              type: "action.approval_digest_migrated",
+              detail: { from: migration.from, to: migration.to, addedBinding: "source_mailbox" },
+            });
+          }
           await this.store.appendEvent({ feedId, cardId: work.cardId, workId, type: "work.approved_action_retry_queued" });
         },
       });

--- a/server/workflow/approvals.ts
+++ b/server/workflow/approvals.ts
@@ -51,6 +51,14 @@ export function actionDigest(card: Card, cardActionId?: string): string {
   return digest({ cardActionId: cardActionId ?? null, action, artifact, ...(sourceMailbox ? { sourceMailbox } : {}), ...(attachments.length ? { attachments } : {}) });
 }
 
+export function legacyActionDigestWithoutSourceMailbox(card: Card, cardActionId?: string): string | undefined {
+  const action = configuredApprovalAction(card, cardActionId);
+  if (!requiresSourceMailboxMatch(card.feedId, action) || !normalizeMailbox(card.sourceMailbox)) return undefined;
+  const artifact = action.artifactBlockId ? card.blocks.find((block) => block.id === action.artifactBlockId) : undefined;
+  const attachments = card.blocks.filter((block) => block.type === "image");
+  return digest({ cardActionId: cardActionId ?? null, action, artifact, ...(attachments.length ? { attachments } : {}) });
+}
+
 export function cleanupDigest(card: Card, instruction: string): string {
   return digest({
     instruction,

--- a/test/approval-mailbox.test.ts
+++ b/test/approval-mailbox.test.ts
@@ -1,9 +1,11 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { AttentionDomain } from "../server/domain";
 import { createLocalRuntime } from "../server/runtime";
+import { actionDigest, legacyActionDigestWithoutSourceMailbox } from "../server/workflow/approvals";
+import type { Card, WorkItem } from "../shared/types";
 const roots: string[] = [];
 async function freshRoot(label: string) {
  const root = await mkdtemp(path.join(os.tmpdir(), `tend-${label}-`)); roots.push(root); return root;
@@ -17,7 +19,10 @@ async function reproMailboxApprovalDrift() {
     id: "mailbox-drift",
     title: "Send this reply",
     why: "The reply is ready.",
-    blocks: [{ id: "draft", type: "editable_text" as const, label: "Draft", value: "Approved text.", editable: true }],
+    blocks: [
+      { id: "source", type: "evidence" as const, label: "Source", items: [{ label: "Original thread", href: "https://mail.google.com/mail/u/0/#inbox/thread-legacy" }] },
+      { id: "draft", type: "editable_text" as const, label: "Draft", value: "Approved text.", editable: true },
+    ],
     actions: [{ id: "send", label: "Send reply", behavior: "approve_action" as const, instruction: "Send the exact reply.", artifactBlockId: "draft", externalMutation: true, mailboxPolicy: "reply_from_source" as const }],
   };
   await domain.upsertCard("inbox", { ...cardInput, sourceMailbox: "first@example.com" });
@@ -30,7 +35,117 @@ async function reproMailboxApprovalDrift() {
   runtime.sqlite.close();
   return { approvedMailbox: "first@example.com", currentMailbox, approvalDigest: approved.approvalDigest };
 }
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
 test("changing the source mailbox invalidates prior approval", async () => {
- try { await reproMailboxApprovalDrift(); }
- finally { await Promise.all(roots.map(root => rm(root, { recursive: true, force: true }))); }
+ await reproMailboxApprovalDrift();
+});
+
+async function legacyApprovalFixture(label: string) {
+  const root = await freshRoot(label);
+  const runtime = await createLocalRuntime(path.join(root, "data"), path.join(root, "attention.db"));
+  const domain = new AttentionDomain(runtime.store);
+  await domain.bindFeed("inbox", "thread-inbox");
+  const sourceSnapshot = { id: "thread-legacy", messages: [{ id: "message-legacy", text: "Please reply." }] };
+  const runId = await domain.recordSourceRun("inbox", "gmail-inbox", [sourceSnapshot], [], {});
+  await domain.recordSweepBatch("inbox", [runId]);
+  const input = {
+    id: "legacy-mailbox-approval",
+    title: "Send this exact reply",
+    why: "The reviewed source still requests a reply.",
+    sourceMailbox: "dan@example.com",
+    sourceRunIds: [runId],
+    blocks: [{ id: "draft", type: "editable_text" as const, label: "Draft", value: "Approved text.", editable: true }],
+    actions: [{ id: "send", label: "Send reply", behavior: "approve_action" as const, instruction: "Send the exact reply to reader@example.com.", artifactBlockId: "draft", externalMutation: true, mailboxPolicy: "reply_from_source" as const }],
+  };
+  await domain.upsertCard("inbox", input);
+  const approved = await domain.runCardAction("inbox", input.id, "send");
+  const card = await runtime.store.readCard("inbox", input.id);
+  const legacyDigest = legacyActionDigestWithoutSourceMailbox(card, "send");
+  if (!legacyDigest) throw new Error("Expected a legacy mailbox digest.");
+  const work = await runtime.store.readWork("inbox", approved.id);
+  work.approvalDigest = legacyDigest;
+  return { runtime, domain, input, card, work, sourceSnapshot, currentDigest: actionDigest(card, "send") };
+}
+
+async function storeRetryState(runtime: Awaited<ReturnType<typeof createLocalRuntime>>, card: Card, work: WorkItem, status: "approved_blocked" | "stale") {
+  work.status = status;
+  work.error = status === "stale"
+    ? "Approval stale - the proposed action or artifact changed after approval."
+    : "Connector temporarily refused the approved send.";
+  card.status = status === "stale" ? "to_review_updated" : "approved_blocked";
+  await runtime.store.writeWork(work);
+  await runtime.store.writeCard(card);
+}
+
+for (const status of ["approved_blocked", "stale"] as const) {
+  test(`migrates an unchanged ${status} pre-mailbox approval exactly once`, async () => {
+    const { runtime, domain, card, work, sourceSnapshot, currentDigest } = await legacyApprovalFixture(`legacy-${status}`);
+    await storeRetryState(runtime, card, work, status);
+    const currentRun = await domain.recordSourceRun("inbox", "gmail-inbox", [sourceSnapshot], [], {});
+    await domain.recordSweepBatch("inbox", [currentRun]);
+
+    const retried = await domain.retryApprovedWork("inbox", work.id);
+    expect(retried.status).toBe("queued");
+    expect(retried.approvalDigest).toBe(currentDigest);
+    expect((await runtime.store.readCard("inbox", card.id)).status).toBe("queued");
+    const events = (await runtime.store.readEvents("inbox")).filter((event) => event.workId === work.id && event.type === "action.approval_digest_migrated");
+    expect(events).toHaveLength(1);
+    expect(events[0].detail).toMatchObject({ from: work.approvalDigest, to: currentDigest, addedBinding: "source_mailbox" });
+    runtime.sqlite.close();
+  });
+}
+
+test("does not migrate a legacy digest after the source mailbox changes", async () => {
+  const { runtime, domain, input, card, work } = await legacyApprovalFixture("legacy-mailbox-changed");
+  await storeRetryState(runtime, card, work, "approved_blocked");
+  await domain.upsertCard("inbox", { ...input, sourceMailbox: "other@example.com" });
+
+  await expect(domain.retryApprovedWork("inbox", work.id)).rejects.toThrow("Approval stale");
+  expect((await runtime.store.readWork("inbox", work.id)).status).toBe("stale");
+  expect((await runtime.store.readEvents("inbox")).filter((event) => event.workId === work.id && event.type === "action.approval_digest_migrated")).toHaveLength(0);
+  runtime.sqlite.close();
+});
+
+test("does not migrate a legacy digest after its source evidence changes", async () => {
+  const { runtime, domain, card, work } = await legacyApprovalFixture("legacy-source-changed");
+  await storeRetryState(runtime, card, work, "approved_blocked");
+  const changedRun = await domain.recordSourceRun("inbox", "gmail-inbox", [{ id: "thread-legacy", messages: [{ id: "message-legacy", text: "The request changed after approval." }] }], [], {});
+  await domain.recordSweepBatch("inbox", [changedRun]);
+
+  await expect(domain.retryApprovedWork("inbox", work.id)).rejects.toThrow("source evidence is stale");
+  expect((await runtime.store.readWork("inbox", work.id)).status).toBe("approved_blocked");
+  expect((await runtime.store.readEvents("inbox")).filter((event) => event.workId === work.id && event.type === "action.approval_digest_migrated")).toHaveLength(0);
+  runtime.sqlite.close();
+});
+
+test("does not revive a legacy approval after a newer approval completed the action", async () => {
+  const { runtime, domain, card, work } = await legacyApprovalFixture("legacy-already-completed");
+  await storeRetryState(runtime, card, work, "stale");
+  const newer = await domain.runCardAction("inbox", card.id, "send");
+  const claimed = await domain.claimWork("inbox", "thread-inbox");
+  if (!claimed || !("capabilityToken" in claimed) || claimed.id !== newer.id) throw new Error("Expected the newer action claim.");
+  const verified = await domain.verifyApprovedAction("inbox", newer.id, claimed.capabilityToken, "dan@example.com");
+  if (!verified.emailDelivery) throw new Error("Expected prepared email delivery.");
+  await domain.completeWork("inbox", newer.id, claimed.capabilityToken, {
+    response: "The newer approval completed.",
+    emailDeliveryReadback: {
+      ...verified.emailDelivery,
+      source: "connector_readback",
+      providerMessageId: "newer-message",
+      readAt: "2026-09-12T12:01:00.000Z",
+    },
+    postAction: {
+      cleanup: { status: "completed", detail: "The exact source row was archived." },
+      disposition: "done",
+    },
+  });
+
+  await expect(domain.retryApprovedWork("inbox", work.id)).rejects.toThrow("newer approval already completed");
+  expect((await runtime.store.readWork("inbox", work.id)).status).toBe("stale");
+  expect((await runtime.store.readEvents("inbox")).filter((event) => event.workId === work.id && event.type === "action.approval_digest_migrated")).toHaveLength(0);
+  runtime.sqlite.close();
 });


### PR DESCRIPTION
A source-mailbox safety upgrade changed the approval digest after several unchanged Inbox sends had already been approved. Retrying those actions incorrectly marked them stale, even though their exact action, artifact, attachments, mailbox, and source evidence had not changed.

This adds a one-time, fail-closed migration for the recognized pre-mailbox digest. Tend migrates and requeues it only when the card has current immutable source evidence and no card update or artifact edit occurred after approval. It supports both blocked work and the exact stale state produced by the failed retry, then records `action.approval_digest_migrated` before issuing a fresh capability token.

A duplicate guard also refuses an older retry when a newer approval for the same card action has already completed. Changed mailboxes, changed source evidence, changed artifacts, missing provenance, unrelated stale work, and already-completed actions remain rejected.

Validation:
- `pnpm check` (442 passed, 1 optional local-Supabase skip)
- `pnpm build`
- focused mailbox migration suite (6 passed)
- isolated rehearsal against a consistent copy of current live state: 6 still-held approvals migrated and requeued with 6 audit events; the superseded Bo approval was rejected because its newer send had completed; live state was not mutated