### PR TITLE
fix(readers): preserve timeout diagnostics

### DIFF
--- a/server/readerAdapters.ts
+++ b/server/readerAdapters.ts
@@ -120,7 +120,7 @@ async function runProcess(binary: string, args: string[], options: {
       if (!failure && options.onLine && lineBuffer.trim()) {
         try { options.onLine(lineBuffer); } catch (error) { failure = error instanceof Error ? error : new Error("Unexpected reader output."); }
       }
-      if (failure) reject(new ReaderExecutionError(failure.message, stdout));
+      if (failure) reject(new ReaderExecutionError(failure.message, JSON.stringify({ stdout, stderr })));
       else resolve({ stdout, stderr, code });
     });
     child.stdin.on("error", () => { /* Process exit is handled above; never let EPIPE crash Tend. */ });

--- a/server/readers.ts
+++ b/server/readers.ts
@@ -414,12 +414,31 @@ export class ReaderRunner {
   private async abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
     if (signal.aborted) throw signal.reason;
     let abort: (() => void) | undefined;
+    let graceTimer: ReturnType<typeof setTimeout> | undefined;
     try {
-      return await Promise.race([promise, new Promise<never>((_, reject) => {
-        abort = () => reject(signal.reason ?? new Error("Reader interrupted."));
+      const settled = promise.then(
+        (value) => {
+          if (signal.aborted) throw signal.reason ?? new Error("Reader interrupted.");
+          return value;
+        },
+        (error) => {
+          if (signal.aborted && !(error instanceof ReaderExecutionError)) {
+            throw signal.reason ?? new Error("Reader interrupted.");
+          }
+          throw error;
+        },
+      );
+      return await Promise.race([settled, new Promise<never>((_, reject) => {
+        abort = () => {
+          graceTimer = setTimeout(
+            () => reject(signal.reason ?? new Error("Reader interrupted.")),
+            Math.min(this.timeoutMs, 2_500),
+          );
+        };
         signal.addEventListener("abort", abort, { once: true });
       })]);
     } finally {
+      if (graceTimer) clearTimeout(graceTimer);
       if (abort) signal.removeEventListener("abort", abort);
     }
   }

--- a/test/readers.test.ts
+++ b/test/readers.test.ts
@@ -168,6 +168,23 @@ describe("native source-run readers", () => {
     await expect(runner.readOutput(run.feedId, run.id, "a")).rejects.toThrow("no recorded output");
   });
 
+  test("timeout preserves diagnostics returned while the adapter shuts down", async () => {
+    const diagnostics = JSON.stringify({ stdout: "partial reader event", stderr: "bounded diagnostic" });
+    const adapter: ReaderAdapter = async (_config, _packet, signal) => new Promise((_resolve, reject) => {
+      signal.addEventListener("abort", () => {
+        setTimeout(() => reject(new ReaderExecutionError("Reader timed out; no automatic retry was attempted.", diagnostics)), 5);
+      }, { once: true });
+    });
+    const { store, runner, run, input } = await setup({ codex: adapter }, 25);
+    await runner.start({ ...input, readers: [configs[0]] });
+    await runner.waitForRun(run.feedId, run.id);
+
+    const saved = await store.readRun(run.feedId, run.id);
+    expect(saved.readers?.[0].status).toBe("failed");
+    expect(saved.readers?.[0].error).toContain("timed out");
+    expect((await runner.readOutput(run.feedId, run.id, "a")).rawOutput).toBe(diagnostics);
+  });
+
   test("server recovery reclaims a dead owner and interrupts abandoned readers without replaying providers", async () => {
     let calls = 0;
     const probed: number[] = [];


### PR DESCRIPTION
Native reader timeouts currently win a promise race before the terminating CLI process can return its buffered diagnostics. The failed receipt therefore loses partial output that could explain long-running Codex or Claude failures.

This keeps the existing timeout terminal and adds a bounded shutdown grace of at most 2.5 seconds. If the adapter returns a `ReaderExecutionError` during that window, Tend saves its bounded private stdout/stderr snapshot; adapters that ignore cancellation still terminate without retry. CLI process failures now package both streams consistently. This does not increase the 15-minute reader limit, enable tools, change models, retry providers, or add a fallback, and it does not claim to explain the observed full-packet timeout.

Independent correctness, reliability, and security review found no remaining blocker. Raw diagnostics remain confined to immutable local snapshots; public receipts and events retain generic bounded errors.

Validation:
- `pnpm check` (438 passed, 1 optional local-Supabase skip)
- `pnpm build`
- focused reader, failure, and API suites (42 passed)
- timeout/cancellation suite repeated 20 times (361 passed)
- `pnpm audit --prod --audit-level high` (no known vulnerabilities)
- no provider calls in tests
