### PR TITLE
chore: ignore managed worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data/
 .wrangler/
 *.log
 .DS_Store
+.worktrees/


### PR DESCRIPTION
Ignore the repository-local `.worktrees/` directory used for isolated development so the canonical live checkout stays clean while feature work remains separate.